### PR TITLE
snprintf is not implemented in Visual Studio 2013 or earlier. Use _snpri...

### DIFF
--- a/src/commonmark.c
+++ b/src/commonmark.c
@@ -11,6 +11,10 @@
 #include "utf8.h"
 #include "scanners.h"
 
+#if defined(_MSC_VER) && (_MSC_VER <=1800)
+#define snprintf _snprintf
+#endif
+
 // Functions to convert cmark_nodes to commonmark strings.
 
 struct render_state {


### PR DESCRIPTION
snprintf is not implemented in Visual Studio 2013 or earlier. Use _snprintf instead.