### PR TITLE
Install compiler-provided system runtime libraries.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -109,6 +109,7 @@ if (MSVC)
     APPEND PROPERTY LINK_FLAGS /INCREMENTAL:NO)
 endif(MSVC)
 
+include (InstallRequiredSystemLibraries)
 install(TARGETS ${PROGRAM} ${LIBRARY}
   RUNTIME DESTINATION bin
   LIBRARY DESTINATION lib


### PR DESCRIPTION
On windows, cmark.exe and cmark.dll depend on msvcr***.dll, this line will automatically install the system runtime libraries.