### PR TITLE
Make it possible to use NULL in setters.

### DIFF
--- a/src/chunk.h
+++ b/src/chunk.h
@@ -78,10 +78,16 @@ static inline void cmark_chunk_set_cstr(cmark_chunk *c, const char *str)
 	if (c->alloc) {
 		free(c->data);
 	}
-	c->len   = strlen(str);
-	c->data  = (unsigned char *)malloc(c->len + 1);
-	c->alloc = 1;
-	memcpy(c->data, str, c->len + 1);
+	if (str == NULL) {
+		c->len   = 0;
+		c->data  = NULL;
+		c->alloc = 0;
+	} else {
+		c->len   = strlen(str);
+		c->data  = (unsigned char *)malloc(c->len + 1);
+		c->alloc = 1;
+		memcpy(c->data, str, c->len + 1);
+	}
 }
 
 static inline cmark_chunk cmark_chunk_literal(const char *data)

--- a/src/node.c
+++ b/src/node.c
@@ -560,7 +560,8 @@ cmark_node_set_url(cmark_node *node, const char *url)
 	case NODE_LINK:
 	case NODE_IMAGE:
 		free(node->as.link.url);
-		node->as.link.url = (unsigned char *)S_strdup(url);
+		node->as.link.url =
+		    (url == NULL) ? NULL : (unsigned char *)S_strdup(url);
 		return 1;
 	default:
 		break;
@@ -598,7 +599,8 @@ cmark_node_set_title(cmark_node *node, const char *title)
 	case NODE_LINK:
 	case NODE_IMAGE:
 		free(node->as.link.title);
-		node->as.link.title = (unsigned char *)S_strdup(title);
+		node->as.link.title =
+		    (title == NULL) ? NULL : (unsigned char *)S_strdup(title);
 		return 1;
 	default:
 		break;


### PR DESCRIPTION
This makes it possible to use null in `cmark_node_set_literal()`,
`cmark_node_set_fence_info()`, `cmark_node_set_url()` and
`cmark_node_set_title()`.  Note that to make it work in the first two I
changed `cmark_chunk_set_cstr()` --- it's used in one other place (in
`commonmark.c`) which seems like it never sends it a NULL.