### PR TITLE
Explicitly add `-fPIC` for static library

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -64,7 +64,7 @@ add_compiler_export_flags()
 
 # Disable the PUBLIC declarations when compiling the executable:
 set_target_properties(${PROGRAM} PROPERTIES
-  COMPILE_FLAGS -DCMARK_STATIC_DEFINE)
+  COMPILE_FLAGS "-DCMARK_STATIC_DEFINE -fPIC")
 
 # Check integrity of node structure when compiled as debug:
 set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -pg -DCMARK_DEBUG_NODES")


### PR DESCRIPTION
I'm not very well acquainted with how `cmake` works. Many resources online indicate that `-fPIC` is set by default when building a static library. 

However, I'm finding that's not the case. When trying to natively calls some Houdini methods in https://github.com/gjtorikian/commonmarker/pull/5, the CI runs into [linking issues](https://travis-ci.org/gjtorikian/commonmarker/jobs/63438886). Setting this flag explicitly resolves these issues. 

Perhaps when `COMPILE_FLAGS` is redefined it overrides the default `-fPIC` setting?
