### PR TITLE
Cope with broken snprintf on Windows

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -128,6 +128,7 @@ install(FILES
 # Feature tests
 include(CheckIncludeFile)
 include(CheckCSourceCompiles)
+include(CheckCSourceRuns)
 include(CheckSymbolExists)
 CHECK_INCLUDE_FILE(stdbool.h HAVE_STDBOOL_H)
 CHECK_C_SOURCE_COMPILES(
@@ -137,6 +138,10 @@ CHECK_C_SOURCE_COMPILES("
   int f(void) __attribute__ (());
   int main() { return 0; }
 " HAVE___ATTRIBUTE__)
+CHECK_C_SOURCE_RUNS("
+  #include <stdio.h>
+  int main() { return snprintf(NULL, 0, \"123\") == 3 ? 0 : 1; }
+" HAVE_C99_SNPRINTF)
 CHECK_SYMBOL_EXISTS(va_copy stdarg.h HAVE_VA_COPY)
 
 CONFIGURE_FILE(

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -175,6 +175,12 @@ int cmark_strbuf_vprintf(cmark_strbuf *buf, const char *format, va_list ap)
 		          buf->asize - buf->size,
 		          format, args
 		      );
+#ifndef HAVE_C99_SNPRINTF
+		// Assume we're on Windows.
+		if (len < 0) {
+			len = _vscprintf(format, args);
+		}
+#endif
 
 		va_end(args);
 

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -21,3 +21,5 @@
 #ifndef HAVE_VA_COPY
   #define va_copy(dest, src) ((dest) = (src))
 #endif
+
+#cmakedefine HAVE_C99_SNPRINTF


### PR DESCRIPTION
On Windows, snprintf returns -1 if the output was truncated. Fall back to
Windows-specific _scprintf.

Fixes issue #44.