### PR TITLE
Fix for UBSAN note

### DIFF
--- a/src/chunk.h
+++ b/src/chunk.h
@@ -65,7 +65,7 @@ static inline const char *cmark_chunk_to_cstr(cmark_chunk *c)
 		return (char *)c->data;
 	}
 	str = (unsigned char *)malloc(c->len + 1);
-	if(str != NULL) {
+	if(c->data != NULL) {
 		memcpy(str, c->data, c->len);
 		str[c->len] = 0;
 	}


### PR DESCRIPTION
UBSAN complains that `memcpy` sometimes gets called with `source= NULL`.