### PR TITLE
Fix for UBSAN note

### DIFF
--- a/src/chunk.h
+++ b/src/chunk.h
@@ -66,7 +66,9 @@ static inline const char *cmark_chunk_to_cstr(cmark_chunk *c)
 	}
 	str = (unsigned char *)malloc(c->len + 1);
 	if(str != NULL) {
-		memcpy(str, c->data, c->len);
+		if(c->len > 0){
+			memcpy(str, c->data, c->len);			
+		}
 		str[c->len] = 0;
 	}
 	c->data  = str;


### PR DESCRIPTION
Do no call `memcpy` with zero bytes. Fixes https://github.com/jgm/cmark/issues/43.