### PR TITLE
Changed version variables to functions.

### DIFF
--- a/api_test/main.c
+++ b/api_test/main.c
@@ -55,8 +55,8 @@ test_continuation_byte(test_batch_runner *runner, const char *utf8);
 static void
 version(test_batch_runner *runner)
 {
-	INT_EQ(runner, cmark_version, CMARK_VERSION, "cmark_version");
-	STR_EQ(runner, cmark_version_string, CMARK_VERSION_STRING,
+	INT_EQ(runner, cmark_version(), CMARK_VERSION, "cmark_version");
+	STR_EQ(runner, cmark_version_string(), CMARK_VERSION_STRING,
 	       "cmark_version_string");
 }
 

--- a/man/man3/cmark.3
+++ b/man/man3/cmark.3
@@ -1,4 +1,4 @@
-.TH cmark 3 "June 16, 2015" "LOCAL" "Library Functions Manual"
+.TH cmark 3 "June 25, 2015" "LOCAL" "Library Functions Manual"
 .SH
 NAME
 .PP
@@ -556,13 +556,7 @@ sequences with the replacement character U+FFFD.
 Version information
 
 .PP
-.nf
-\fC
-.RS 0n
-extern const int cmark_version;
-.RE
-\f[]
-.fi
+\fIint\f[] \fBcmark_version\f[](\fI\f[])
 
 .PP
 The library version as integer for runtime checks. Also available as
@@ -577,13 +571,7 @@ Bits 0\-7 contain the patchlevel.
 In hexadecimal format, the number 0x010203 represents version 1.2.3.
 
 .PP
-.nf
-\fC
-.RS 0n
-extern const char cmark_version_string[];
-.RE
-\f[]
-.fi
+\fIconst char *\f[] \fBcmark_version_string\f[](\fI\f[])
 
 .PP
 The library version string for runtime checks. Also available as

--- a/src/cmark.c
+++ b/src/cmark.c
@@ -6,8 +6,15 @@
 #include "cmark.h"
 #include "buffer.h"
 
-const int cmark_version = CMARK_VERSION;
-const char cmark_version_string[] = CMARK_VERSION_STRING;
+int cmark_version()
+{
+	return CMARK_VERSION;
+}
+
+const char *cmark_version_string()
+{
+	return CMARK_VERSION_STRING;
+}
 
 char *cmark_markdown_to_html(const char *text, size_t len, int options)
 {

--- a/src/cmark.h
+++ b/src/cmark.h
@@ -525,13 +525,13 @@ char *cmark_render_commonmark(cmark_node *root, int options, int width);
  * In hexadecimal format, the number 0x010203 represents version 1.2.3.
  */
 CMARK_EXPORT
-extern const int cmark_version;
+int cmark_version();
 
 /** The library version string for runtime checks. Also available as
  * macro CMARK_VERSION_STRING for compile time checks.
  */
 CMARK_EXPORT
-extern const char cmark_version_string[];
+const char *cmark_version_string();
 
 /** # AUTHORS
  *


### PR DESCRIPTION
This is easier to access using ffi, since some languages, like C#
like to use only function interfaces for accessing library
functionality.

fixes #60