### PR TITLE
Split roundtrip_test and leakcheck.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,10 @@ script:
  - |
      if [ ${TRAVIS_OS_NAME:-'linux'} = 'linux' ]
      then
-         make roundtrip_test
-         make leakcheck
+        make roundtrip_test
+     fi
+ - |
+     if [ ${TRAVIS_OS_NAME:-'linux'} = 'linux' ]
+     then
+        make leakcheck
      fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,10 +29,10 @@ script:
  - |
      if [ ${TRAVIS_OS_NAME:-'linux'} = 'linux' ]
      then
-        make roundtrip_test
+         make roundtrip_test
      fi
  - |
      if [ ${TRAVIS_OS_NAME:-'linux'} = 'linux' ]
      then
-        make leakcheck
+         make leakcheck
      fi


### PR DESCRIPTION
CI status became green even if roundtrip_test failed, since `then` block was not suspended when $? was non-zero. Splitting roundtrip_test and leakcheck addresses this problem.
With this change, builds check ``${TRAVIS_OS_NAME}`` twice, but checking a variable is cheap enough.