### PR TITLE
Prefix utf8proc functions to avoid conflict with existing library

### DIFF
--- a/src/blocks.c
+++ b/src/blocks.c
@@ -594,7 +594,7 @@ static void S_process_line(cmark_parser *parser, const unsigned char *buffer,
   bool maybe_lazy;
 
   if (parser->options & CMARK_OPT_VALIDATE_UTF8) {
-    utf8proc_check(parser->curline, buffer, bytes);
+    cmark_utf8proc_check(parser->curline, buffer, bytes);
   } else {
     cmark_strbuf_put(parser->curline, buffer, bytes);
   }

--- a/src/houdini_html_u.c
+++ b/src/houdini_html_u.c
@@ -75,7 +75,7 @@ bufsize_t houdini_unescape_ent(cmark_strbuf *ob, const uint8_t *src,
           codepoint >= 0x110000) {
         codepoint = 0xFFFD;
       }
-      utf8proc_encode_char(codepoint, ob);
+      cmark_utf8proc_encode_char(codepoint, ob);
       return i + 1;
     }
   }

--- a/src/inlines.c
+++ b/src/inlines.c
@@ -283,7 +283,7 @@ static int scan_delims(subject *subj, unsigned char c, bool *can_open,
     while (peek_at(subj, before_char_pos) >> 6 == 2 && before_char_pos > 0) {
       before_char_pos -= 1;
     }
-    len = utf8proc_iterate(subj->input.data + before_char_pos,
+    len = cmark_utf8proc_iterate(subj->input.data + before_char_pos,
                            subj->pos - before_char_pos, &before_char);
     if (len == -1) {
       before_char = 10;
@@ -300,24 +300,24 @@ static int scan_delims(subject *subj, unsigned char c, bool *can_open,
     }
   }
 
-  len = utf8proc_iterate(subj->input.data + subj->pos,
+  len = cmark_utf8proc_iterate(subj->input.data + subj->pos,
                          subj->input.len - subj->pos, &after_char);
   if (len == -1) {
     after_char = 10;
   }
-  left_flanking = numdelims > 0 && !utf8proc_is_space(after_char) &&
-                  !(utf8proc_is_punctuation(after_char) &&
-                    !utf8proc_is_space(before_char) &&
-                    !utf8proc_is_punctuation(before_char));
+  left_flanking = numdelims > 0 && !cmark_utf8proc_is_space(after_char) &&
+                  !(cmark_utf8proc_is_punctuation(after_char) &&
+                    !cmark_utf8proc_is_space(before_char) &&
+                    !cmark_utf8proc_is_punctuation(before_char));
   right_flanking =
-      numdelims > 0 && !utf8proc_is_space(before_char) &&
-      !(utf8proc_is_punctuation(before_char) &&
-        !utf8proc_is_space(after_char) && !utf8proc_is_punctuation(after_char));
+      numdelims > 0 && !cmark_utf8proc_is_space(before_char) &&
+      !(cmark_utf8proc_is_punctuation(before_char) &&
+        !cmark_utf8proc_is_space(after_char) && !cmark_utf8proc_is_punctuation(after_char));
   if (c == '_') {
     *can_open = left_flanking &&
-                (!right_flanking || utf8proc_is_punctuation(before_char));
+                (!right_flanking || cmark_utf8proc_is_punctuation(before_char));
     *can_close = right_flanking &&
-                 (!left_flanking || utf8proc_is_punctuation(after_char));
+                 (!left_flanking || cmark_utf8proc_is_punctuation(after_char));
   } else if (c == '\'' || c == '"') {
     *can_open = left_flanking && !right_flanking;
     *can_close = right_flanking;

--- a/src/references.c
+++ b/src/references.c
@@ -37,7 +37,7 @@ static unsigned char *normalize_reference(cmark_chunk *ref) {
   if (ref->len == 0)
     return NULL;
 
-  utf8proc_case_fold(&normalized, ref->data, ref->len);
+  cmark_utf8proc_case_fold(&normalized, ref->data, ref->len);
   cmark_strbuf_trim(&normalized);
   cmark_strbuf_normalize_whitespace(&normalized);
 

--- a/src/render.c
+++ b/src/render.c
@@ -55,7 +55,7 @@ static void S_out(cmark_renderer *renderer, const char *source, bool wrap,
       renderer->column = renderer->prefix->size;
     }
 
-    len = utf8proc_iterate((const uint8_t *)source + i, length - i, &c);
+    len = cmark_utf8proc_iterate((const uint8_t *)source + i, length - i, &c);
     if (len == -1) { // error condition
       return;        // return without rendering rest of string
     }
@@ -118,7 +118,7 @@ void cmark_render_ascii(cmark_renderer *renderer, const char *s) {
 }
 
 void cmark_render_code_point(cmark_renderer *renderer, uint32_t c) {
-  utf8proc_encode_char(c, renderer->buffer);
+  cmark_utf8proc_encode_char(c, renderer->buffer);
   renderer->column += 1;
 }
 

--- a/src/utf8.c
+++ b/src/utf8.c
@@ -107,7 +107,7 @@ static int utf8proc_valid(const uint8_t *str, bufsize_t str_len) {
   return length;
 }
 
-void utf8proc_check(cmark_strbuf *ob, const uint8_t *line, bufsize_t size) {
+void cmark_utf8proc_check(cmark_strbuf *ob, const uint8_t *line, bufsize_t size) {
   bufsize_t i = 0;
 
   while (i < size) {
@@ -146,7 +146,7 @@ void utf8proc_check(cmark_strbuf *ob, const uint8_t *line, bufsize_t size) {
   }
 }
 
-int utf8proc_iterate(const uint8_t *str, bufsize_t str_len, int32_t *dst) {
+int cmark_utf8proc_iterate(const uint8_t *str, bufsize_t str_len, int32_t *dst) {
   int length;
   int32_t uc = -1;
 
@@ -184,7 +184,7 @@ int utf8proc_iterate(const uint8_t *str, bufsize_t str_len, int32_t *dst) {
   return length;
 }
 
-void utf8proc_encode_char(int32_t uc, cmark_strbuf *buf) {
+void cmark_utf8proc_encode_char(int32_t uc, cmark_strbuf *buf) {
   uint8_t dst[4];
   bufsize_t len = 0;
 
@@ -222,13 +222,13 @@ void utf8proc_encode_char(int32_t uc, cmark_strbuf *buf) {
   cmark_strbuf_put(buf, dst, len);
 }
 
-void utf8proc_case_fold(cmark_strbuf *dest, const uint8_t *str, bufsize_t len) {
+void cmark_utf8proc_case_fold(cmark_strbuf *dest, const uint8_t *str, bufsize_t len) {
   int32_t c;
 
-#define bufpush(x) utf8proc_encode_char(x, dest)
+#define bufpush(x) cmark_utf8proc_encode_char(x, dest)
 
   while (len > 0) {
-    bufsize_t char_len = utf8proc_iterate(str, len, &c);
+    bufsize_t char_len = cmark_utf8proc_iterate(str, len, &c);
 
     if (char_len >= 0) {
 #include "case_fold_switch.inc"
@@ -243,14 +243,14 @@ void utf8proc_case_fold(cmark_strbuf *dest, const uint8_t *str, bufsize_t len) {
 }
 
 // matches anything in the Zs class, plus LF, CR, TAB, FF.
-int utf8proc_is_space(int32_t uc) {
+int cmark_utf8proc_is_space(int32_t uc) {
   return (uc == 9 || uc == 10 || uc == 12 || uc == 13 || uc == 32 ||
           uc == 160 || uc == 5760 || (uc >= 8192 && uc <= 8202) || uc == 8239 ||
           uc == 8287 || uc == 12288);
 }
 
 // matches anything in the P[cdefios] classes.
-int utf8proc_is_punctuation(int32_t uc) {
+int cmark_utf8proc_is_punctuation(int32_t uc) {
   return (
       (uc < 128 && cmark_ispunct((char)uc)) || uc == 161 || uc == 167 ||
       uc == 171 || uc == 182 || uc == 183 || uc == 187 || uc == 191 ||

--- a/src/utf8.h
+++ b/src/utf8.h
@@ -8,12 +8,12 @@
 extern "C" {
 #endif
 
-void utf8proc_case_fold(cmark_strbuf *dest, const uint8_t *str, bufsize_t len);
-void utf8proc_encode_char(int32_t uc, cmark_strbuf *buf);
-int utf8proc_iterate(const uint8_t *str, bufsize_t str_len, int32_t *dst);
-void utf8proc_check(cmark_strbuf *dest, const uint8_t *line, bufsize_t size);
-int utf8proc_is_space(int32_t uc);
-int utf8proc_is_punctuation(int32_t uc);
+void cmark_utf8proc_case_fold(cmark_strbuf *dest, const uint8_t *str, bufsize_t len);
+void cmark_utf8proc_encode_char(int32_t uc, cmark_strbuf *buf);
+int cmark_utf8proc_iterate(const uint8_t *str, bufsize_t str_len, int32_t *dst);
+void cmark_utf8proc_check(cmark_strbuf *dest, const uint8_t *line, bufsize_t size);
+int cmark_utf8proc_is_space(int32_t uc);
+int cmark_utf8proc_is_punctuation(int32_t uc);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
There are linker errors when the library is used with a program that already uses utf8proc, so add prefixes to avoid conflicts.