### PR TITLE
Fix FileNotFoundError errors on tests when cmark is built from anothe…

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -27,20 +27,20 @@ IF (PYTHONINTERP_FOUND)
 
   add_test(spectest_library
     ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/spec_tests.py" "--no-normalize" "--spec"
-    "${CMAKE_SOURCE_DIR}/test/spec.txt" "--library-dir" "${CMAKE_BINARY_DIR}/src"
+    "${CMAKE_CURRENT_SOURCE_DIR}/spec.txt" "--library-dir" "${CMAKE_CURRENT_BINARY_DIR}/../src"
     )
 
   add_test(pathological_tests_library
     ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/pathological_tests.py"
-    "--library-dir" "${CMAKE_BINARY_DIR}/src"
+    "--library-dir" "${CMAKE_CURRENT_BINARY_DIR}/../src"
     )
 
   add_test(spectest_executable
-    ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/spec_tests.py" "--no-normalize" "--spec" "${CMAKE_SOURCE_DIR}/test/spec.txt" "--program" "${CMAKE_BINARY_DIR}/src/cmark"
+    ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/spec_tests.py" "--no-normalize" "--spec" "${CMAKE_CURRENT_SOURCE_DIR}/spec.txt" "--program" "${CMAKE_CURRENT_BINARY_DIR}/../src/cmark"
     )
 
   add_test(smartpuncttest_executable
-    ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/spec_tests.py" "--no-normalize" "--spec" "${CMAKE_SOURCE_DIR}/test/smart_punct.txt" "--program" "${CMAKE_BINARY_DIR}/src/cmark --smart"
+    ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/spec_tests.py" "--no-normalize" "--spec" "${CMAKE_CURRENT_SOURCE_DIR}/smart_punct.txt" "--program" "${CMAKE_CURRENT_BINARY_DIR}/../src/cmark --smart"
     )
 
 ELSE(PYTHONINTERP_FOUND)


### PR DESCRIPTION
…r project via add_subdirectory()

CMAKE_SOURCE_DIR will refer to the top-level source directory, not cmark, so CMAKE_CURRENT_SOURCE_DIR must be used. Also the same for CMAKE_BINARY_DIR. Ideally it should be using the TARGET_FILE CMake generator to get a target's location instead of hard coding the path, but that requires CMake 3.0 or greater.