### PR TITLE
Add option to disable tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,11 +13,17 @@ set(PROJECT_VERSION_MINOR 21)
 set(PROJECT_VERSION_PATCH 0)
 set(PROJECT_VERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH} )
 
+option(CMARK_TESTS "Build cmark tests and enable testing" ON)
+
 add_subdirectory(src)
-add_subdirectory(api_test)
+if(CMARK_TESTS)
+  add_subdirectory(api_test)
+endif()
 add_subdirectory(man)
-enable_testing()
-add_subdirectory(test testdir)
+if(CMARK_TESTS)
+  enable_testing()
+  add_subdirectory(test testdir)
+endif()
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "Release" CACHE STRING


### PR DESCRIPTION
I use cmark via add_subdirectory, and also use CTest, but don't care about running cmark tests in the main project, so this option can be used to disable them altogether (on by default).