### PR TITLE
Better handle libdir

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,8 @@
+if(NOT LIB_INSTALL_DIR)
+  set(LIB_INSTALL_DIR "lib" CACHE STRING
+  "Set the installation directory for libraries." FORCE)
+endif(NOT LIB_INSTALL_DIR)
+
 cmake_minimum_required(VERSION 2.8)
 set(LIBRARY "libcmark")
 set(STATICLIBRARY "libcmark_static")
@@ -55,7 +60,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmark_version.h.in
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/libcmark.pc.in
   ${CMAKE_CURRENT_BINARY_DIR}/libcmark.pc @ONLY)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libcmark.pc
-  DESTINATION lib/pkgconfig)
+  DESTINATION ${LIB_INSTALL_DIR}/pkgconfig)
 
 include (GenerateExportHeader)
 
@@ -119,7 +124,7 @@ set(CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_NO_WARNINGS ON)
 include (InstallRequiredSystemLibraries)
 install(TARGETS ${PROGRAM} ${LIBRARY}
   RUNTIME DESTINATION bin
-  LIBRARY DESTINATION lib
+  LIBRARY DESTINATION ${LIB_INSTALL_DIR}
   )
 
 install(FILES


### PR DESCRIPTION
On some OSes we want to install the library in a different location depending on the system architecture.

For example, on a 64 bits Fedora system, the library should be installed in `/usr/lib64`, as opposed to the traditional `/usr/lib`.

This commit allows the builder to specify their own library installation directory, using the variable that the Fedora build process already defines.