### PR TITLE
Python 3.5 compatibility fix: add placeholder for HTMLParseError

### DIFF
--- a/test/normalize.py
+++ b/test/normalize.py
@@ -1,5 +1,14 @@
 # -*- coding: utf-8 -*-
-from html.parser import HTMLParser, HTMLParseError
+from html.parser import HTMLParser
+
+try:
+    from html.parser import HTMLParseError
+except ImportError:
+    # HTMLParseError was removed in Python 3.5. It could never be
+    # thrown, so we define a placeholder instead.
+    class HTMLParseError(Exception):
+        pass
+
 from html.entities import name2codepoint
 import sys
 import re


### PR DESCRIPTION
See #83 for details of the issue.

`HTMLParseError` was removed in Python 3.5. Since it could never be thrown in Python 3.5+, we simply define a placeholder when `HTMLParseError` cannot be imported.