### PR TITLE
commonmark: fix size_t to int

### DIFF
--- a/src/commonmark.c
+++ b/src/commonmark.c
@@ -95,7 +95,7 @@ static int shortest_unused_backtick_sequence(const char *code) {
     used = used >> 1;
     i++;
   }
-  return i;
+  return (int)i;
 }
 
 static bool is_autolink(cmark_node *node) {


### PR DESCRIPTION
This fixes an MSVC warning "conversion from 'size_t' to 'int', possible loss of data"