### PR TITLE
Correct string length in cmark_parse_document example.

### DIFF
--- a/man/man3/cmark.3
+++ b/man/man3/cmark.3
@@ -1,4 +1,4 @@
-.TH cmark 3 "August 07, 2015" "LOCAL" "Library Functions Manual"
+.TH cmark 3 "October 28, 2015" "LOCAL" "Library Functions Manual"
 .SH
 NAME
 .PP
@@ -402,7 +402,7 @@ Simple interface:
 .IP
 .nf
 \f[C]
-cmark_node *document = cmark_parse_document("Hello *world*", 12,
+cmark_node *document = cmark_parse_document("Hello *world*", 13,
                                             CMARK_OPT_DEFAULT);
 \f[]
 .fi

--- a/src/cmark.h
+++ b/src/cmark.h
@@ -368,7 +368,7 @@ CMARK_EXPORT void cmark_consolidate_text_nodes(cmark_node *root);
  *
  * Simple interface:
  *
- *     cmark_node *document = cmark_parse_document("Hello *world*", 12,
+ *     cmark_node *document = cmark_parse_document("Hello *world*", 13,
  *                                                 CMARK_OPT_DEFAULT);
  *
  * Streaming interface:


### PR DESCRIPTION
Currently, the example doesn't include the final `*`.