### PR TITLE
Fix non-ASCII end-of-line character check

### DIFF
--- a/src/cmark_ctype.c
+++ b/src/cmark_ctype.c
@@ -4,7 +4,7 @@
 
 /** 1 = space, 2 = punct, 3 = digit, 4 = alpha, 0 = other
  */
-static const int8_t cmark_ctype_class[256] = {
+static const uint8_t cmark_ctype_class[256] = {
     /*      0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f */
     /* 0 */ 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 1, 0, 0,
     /* 1 */ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -26,17 +26,17 @@ static const int8_t cmark_ctype_class[256] = {
 /**
  * Returns 1 if c is a "whitespace" character as defined by the spec.
  */
-int cmark_isspace(char c) { return cmark_ctype_class[(int8_t)c] == 1; }
+int cmark_isspace(char c) { return cmark_ctype_class[(uint8_t)c] == 1; }
 
 /**
  * Returns 1 if c is an ascii punctuation character.
  */
-int cmark_ispunct(char c) { return cmark_ctype_class[(int8_t)c] == 2; }
+int cmark_ispunct(char c) { return cmark_ctype_class[(uint8_t)c] == 2; }
 
 int cmark_isalnum(char c) {
-  int8_t result;
-  result = cmark_ctype_class[(int8_t)c];
+  uint8_t result;
+  result = cmark_ctype_class[(uint8_t)c];
   return (result == 3 || result == 4);
 }
 
-int cmark_isdigit(char c) { return cmark_ctype_class[(int8_t)c] == 3; }
+int cmark_isdigit(char c) { return cmark_ctype_class[(uint8_t)c] == 3; }


### PR DESCRIPTION
When a line in markdown ends with character, that does not fit in first 127 charcodes, the cmark_isspace function, previously taking int8_t, goes out of bounds of cmark_ctype_class array. All int8_t where thus changed to uint8_t.