### PR TITLE
Moved the cmake minimum version to top line

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(cmark)
 cmake_minimum_required(VERSION 2.8.9)
+project(cmark)
 include("FindAsan.cmake")
 
 if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")


### PR DESCRIPTION
In the file CMakeLists.txt, the required version should be placed to top line. The information could not used at CMake/Modules/CYGWIN.cmake under Cygwin.