### PR TITLE
Compile in plain C mode with MSVC 12.0 or newer

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,14 +2,16 @@ environment:
   PYTHON: "C:\\Python34-x64"
   PYTHON_VERSION: "3.4.3"
   PYTHON_ARCH: "64"
+  matrix:
+    - MSVC_VERSION: 10
+    - MSVC_VERSION: 12
 
 # set up for nmake:
 install:
-  - '"C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x64'
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
 
 build_script:
-  - 'nmake'
+  - 'tools\appveyor-build.bat'
 
 test_script:
   - 'nmake test'

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -169,8 +169,8 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -std=c99 -pedantic")
 endif()
 
-# Compile as C++ under MSVC
-if(MSVC)
+# Compile as C++ under MSVC older than 12.0
+if(MSVC AND MSVC_VERSION LESS 1800)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /TP")
 endif()
 

--- a/src/blocks.c
+++ b/src/blocks.c
@@ -30,11 +30,11 @@
 
 #define peek_at(i, n) (i)->data[n]
 
-static inline bool S_is_line_end_char(char c) {
+static CMARK_INLINE bool S_is_line_end_char(char c) {
   return (c == '\n' || c == '\r');
 }
 
-static inline bool S_is_space_or_tab(char c) {
+static CMARK_INLINE bool S_is_space_or_tab(char c) {
   return (c == ' ' || c == '\t');
 }
 
@@ -126,7 +126,7 @@ static bool is_blank(cmark_strbuf *s, bufsize_t offset) {
   return true;
 }
 
-static inline bool can_contain(cmark_node_type parent_type,
+static CMARK_INLINE bool can_contain(cmark_node_type parent_type,
                                cmark_node_type child_type) {
   return (parent_type == CMARK_NODE_DOCUMENT ||
           parent_type == CMARK_NODE_BLOCK_QUOTE ||
@@ -134,13 +134,13 @@ static inline bool can_contain(cmark_node_type parent_type,
           (parent_type == CMARK_NODE_LIST && child_type == CMARK_NODE_ITEM));
 }
 
-static inline bool accepts_lines(cmark_node_type block_type) {
+static CMARK_INLINE bool accepts_lines(cmark_node_type block_type) {
   return (block_type == CMARK_NODE_PARAGRAPH ||
           block_type == CMARK_NODE_HEADING ||
           block_type == CMARK_NODE_CODE_BLOCK);
 }
 
-static inline bool contains_inlines(cmark_node_type block_type) {
+static CMARK_INLINE bool contains_inlines(cmark_node_type block_type) {
   return (block_type == CMARK_NODE_PARAGRAPH ||
           block_type == CMARK_NODE_HEADING);
 }

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -33,7 +33,7 @@ void cmark_strbuf_overflow_err() {
   abort();
 }
 
-static inline void S_strbuf_grow_by(cmark_strbuf *buf, size_t add) {
+static CMARK_INLINE void S_strbuf_grow_by(cmark_strbuf *buf, size_t add) {
   size_t target_size = (size_t)buf->size + add;
 
   if (target_size < add            /* Integer overflow. */

--- a/src/commonmark.c
+++ b/src/commonmark.c
@@ -20,7 +20,7 @@
 
 // Functions to convert cmark_nodes to commonmark strings.
 
-static inline void outc(cmark_renderer *renderer, cmark_escaping escape,
+static CMARK_INLINE void outc(cmark_renderer *renderer, cmark_escaping escape,
                         int32_t c, unsigned char nextc) {
   bool needs_escaping = false;
   bool follows_digit =

--- a/src/commonmark.c
+++ b/src/commonmark.c
@@ -17,6 +17,8 @@
 #define LIT(s) renderer->out(renderer, s, false, LITERAL)
 #define CR() renderer->cr(renderer)
 #define BLANKLINE() renderer->blankline(renderer)
+#define ENCODED_SIZE 20
+#define LISTMARKER_SIZE 20
 
 // Functions to convert cmark_nodes to commonmark strings.
 
@@ -26,7 +28,6 @@ static CMARK_INLINE void outc(cmark_renderer *renderer, cmark_escaping escape,
   bool follows_digit =
       renderer->buffer->size > 0 &&
       cmark_isdigit(renderer->buffer->ptr[renderer->buffer->size - 1]);
-  const size_t ENCODED_SIZE = 20;
   char encoded[ENCODED_SIZE];
 
   needs_escaping =
@@ -168,7 +169,6 @@ static int S_render_node(cmark_renderer *renderer, cmark_node *node,
   bool entering = (ev_type == CMARK_EVENT_ENTER);
   const char *info, *code, *title;
   size_t info_len, code_len;
-  const size_t LISTMARKER_SIZE = 20;
   char listmarker[LISTMARKER_SIZE];
   char *emph_delim;
   bufsize_t marker_width;

--- a/src/html.c
+++ b/src/html.c
@@ -10,6 +10,8 @@
 #include "houdini.h"
 #include "scanners.h"
 
+#define BUFFER_SIZE 100
+
 // Functions to convert cmark_nodes to HTML strings.
 
 static void escape_html(cmark_strbuf *dest, const unsigned char *source,
@@ -29,7 +31,6 @@ struct render_state {
 
 static void S_render_sourcepos(cmark_node *node, cmark_strbuf *html,
                                int options) {
-  const size_t BUFFER_SIZE = 100;
   char buffer[BUFFER_SIZE];
   if (CMARK_OPT_SOURCEPOS & options) {
     snprintf(buffer, BUFFER_SIZE, " data-sourcepos=\"%d:%d-%d:%d\"",
@@ -47,7 +48,6 @@ static int S_render_node(cmark_node *node, cmark_event_type ev_type,
   char start_heading[] = "<h0";
   char end_heading[] = "</h0";
   bool tight;
-  const size_t BUFFER_SIZE = 100;
   char buffer[BUFFER_SIZE];
 
   bool entering = (ev_type == CMARK_EVENT_ENTER);

--- a/src/html.c
+++ b/src/html.c
@@ -17,7 +17,7 @@ static void escape_html(cmark_strbuf *dest, const unsigned char *source,
   houdini_escape_html0(dest, source, length, 0);
 }
 
-static inline void cr(cmark_strbuf *html) {
+static CMARK_INLINE void cr(cmark_strbuf *html) {
   if (html->size && html->ptr[html->size - 1] != '\n')
     cmark_strbuf_putc(html, '\n');
 }

--- a/src/inlines.c
+++ b/src/inlines.c
@@ -48,7 +48,7 @@ typedef struct {
   delimiter *last_delim;
 } subject;
 
-static inline bool S_is_line_end_char(char c) {
+static CMARK_INLINE bool S_is_line_end_char(char c) {
   return (c == '\n' || c == '\r');
 }
 
@@ -62,7 +62,7 @@ static void subject_from_buf(subject *e, cmark_strbuf *buffer,
 static bufsize_t subject_find_special_char(subject *subj, int options);
 
 // Create an inline with a literal string value.
-static inline cmark_node *make_literal(cmark_node_type t, cmark_chunk s) {
+static CMARK_INLINE cmark_node *make_literal(cmark_node_type t, cmark_chunk s) {
   cmark_node *e = (cmark_node *)calloc(1, sizeof(*e));
   if (e != NULL) {
     e->type = t;
@@ -81,7 +81,7 @@ static inline cmark_node *make_literal(cmark_node_type t, cmark_chunk s) {
 }
 
 // Create an inline with no value.
-static inline cmark_node *make_simple(cmark_node_type t) {
+static CMARK_INLINE cmark_node *make_simple(cmark_node_type t) {
   cmark_node *e = (cmark_node *)calloc(1, sizeof(*e));
   if (e != NULL) {
     e->type = t;
@@ -141,7 +141,7 @@ static cmark_chunk cmark_clean_autolink(cmark_chunk *url, int is_email) {
   return cmark_chunk_buf_detach(&buf);
 }
 
-static inline cmark_node *make_autolink(cmark_chunk url, int is_email) {
+static CMARK_INLINE cmark_node *make_autolink(cmark_chunk url, int is_email) {
   cmark_node *link = make_simple(CMARK_NODE_LINK);
   link->as.link.url = cmark_clean_autolink(&url, is_email);
   link->as.link.title = cmark_chunk_literal("");
@@ -159,28 +159,28 @@ static void subject_from_buf(subject *e, cmark_strbuf *buffer,
   e->last_delim = NULL;
 }
 
-static inline int isbacktick(int c) { return (c == '`'); }
+static CMARK_INLINE int isbacktick(int c) { return (c == '`'); }
 
-static inline unsigned char peek_char(subject *subj) {
+static CMARK_INLINE unsigned char peek_char(subject *subj) {
   // NULL bytes should have been stripped out by now.  If they're
   // present, it's a programming error:
   assert(!(subj->pos < subj->input.len && subj->input.data[subj->pos] == 0));
   return (subj->pos < subj->input.len) ? subj->input.data[subj->pos] : 0;
 }
 
-static inline unsigned char peek_at(subject *subj, bufsize_t pos) {
+static CMARK_INLINE unsigned char peek_at(subject *subj, bufsize_t pos) {
   return subj->input.data[pos];
 }
 
 // Return true if there are more characters in the subject.
-static inline int is_eof(subject *subj) {
+static CMARK_INLINE int is_eof(subject *subj) {
   return (subj->pos >= subj->input.len);
 }
 
 // Advance the subject.  Doesn't check for eof.
 #define advance(subj) (subj)->pos += 1
 
-static inline bool skip_spaces(subject *subj) {
+static CMARK_INLINE bool skip_spaces(subject *subj) {
   bool skipped = false;
   while (peek_char(subj) == ' ' || peek_char(subj) == '\t') {
     advance(subj);
@@ -189,7 +189,7 @@ static inline bool skip_spaces(subject *subj) {
   return skipped;
 }
 
-static inline bool skip_line_end(subject *subj) {
+static CMARK_INLINE bool skip_line_end(subject *subj) {
   bool seen_line_end_char = false;
   if (peek_char(subj) == '\r') {
     advance(subj);
@@ -203,7 +203,7 @@ static inline bool skip_line_end(subject *subj) {
 }
 
 // Take characters while a predicate holds, and return a string.
-static inline cmark_chunk take_while(subject *subj, int (*f)(int)) {
+static CMARK_INLINE cmark_chunk take_while(subject *subj, int (*f)(int)) {
   unsigned char c;
   bufsize_t startpos = subj->pos;
   bufsize_t len = 0;

--- a/src/latex.c
+++ b/src/latex.c
@@ -17,6 +17,7 @@
 #define LIT(s) renderer->out(renderer, s, false, LITERAL)
 #define CR() renderer->cr(renderer)
 #define BLANKLINE() renderer->blankline(renderer)
+#define LIST_NUMBER_STRING_SIZE 20
 
 static CMARK_INLINE void outc(cmark_renderer *renderer, cmark_escaping escape,
                         int32_t c, unsigned char nextc) {
@@ -217,7 +218,6 @@ static int S_get_enumlevel(cmark_node *node) {
 static int S_render_node(cmark_renderer *renderer, cmark_node *node,
                          cmark_event_type ev_type, int options) {
   int list_number;
-  const size_t LIST_NUMBER_STRING_SIZE = 20;
   char list_number_string[LIST_NUMBER_STRING_SIZE];
   bool entering = (ev_type == CMARK_EVENT_ENTER);
   cmark_list_type list_type;

--- a/src/latex.c
+++ b/src/latex.c
@@ -18,7 +18,7 @@
 #define CR() renderer->cr(renderer)
 #define BLANKLINE() renderer->blankline(renderer)
 
-static inline void outc(cmark_renderer *renderer, cmark_escaping escape,
+static CMARK_INLINE void outc(cmark_renderer *renderer, cmark_escaping escape,
                         int32_t c, unsigned char nextc) {
   if (escape == LITERAL) {
     cmark_render_code_point(renderer, c);

--- a/src/man.c
+++ b/src/man.c
@@ -14,6 +14,7 @@
 #define LIT(s) renderer->out(renderer, s, false, LITERAL)
 #define CR() renderer->cr(renderer)
 #define BLANKLINE() renderer->blankline(renderer)
+#define LIST_NUMBER_SIZE 20
 
 // Functions to convert cmark_nodes to groff man strings.
 static void S_outc(cmark_renderer *renderer, cmark_escaping escape, int32_t c,
@@ -110,7 +111,6 @@ static int S_render_node(cmark_renderer *renderer, cmark_node *node,
           tmp = tmp->prev;
           list_number += 1;
         }
-        const size_t LIST_NUMBER_SIZE = 20;
         char list_number_s[LIST_NUMBER_SIZE];
         snprintf(list_number_s, LIST_NUMBER_SIZE, "\"%d.\" 4", list_number);
         LIT(list_number_s);

--- a/src/node.c
+++ b/src/node.c
@@ -6,7 +6,7 @@
 
 static void S_node_unlink(cmark_node *node);
 
-static inline bool S_is_block(cmark_node *node) {
+static CMARK_INLINE bool S_is_block(cmark_node *node) {
   if (node == NULL) {
     return false;
   }
@@ -14,7 +14,7 @@ static inline bool S_is_block(cmark_node *node) {
          node->type <= CMARK_NODE_LAST_BLOCK;
 }
 
-static inline bool S_is_inline(cmark_node *node) {
+static CMARK_INLINE bool S_is_inline(cmark_node *node) {
   if (node == NULL) {
     return false;
   }

--- a/src/render.c
+++ b/src/render.c
@@ -5,13 +5,13 @@
 #include "utf8.h"
 #include "render.h"
 
-static inline void S_cr(cmark_renderer *renderer) {
+static CMARK_INLINE void S_cr(cmark_renderer *renderer) {
   if (renderer->need_cr < 1) {
     renderer->need_cr = 1;
   }
 }
 
-static inline void S_blankline(cmark_renderer *renderer) {
+static CMARK_INLINE void S_blankline(cmark_renderer *renderer) {
   if (renderer->need_cr < 2) {
     renderer->need_cr = 2;
   }

--- a/src/xml.c
+++ b/src/xml.c
@@ -21,7 +21,7 @@ struct render_state {
   int indent;
 };
 
-static inline void indent(struct render_state *state) {
+static CMARK_INLINE void indent(struct render_state *state) {
   int i;
   for (i = 0; i < state->indent; i++) {
     cmark_strbuf_putc(state->xml, ' ');

--- a/src/xml.c
+++ b/src/xml.c
@@ -9,6 +9,8 @@
 #include "buffer.h"
 #include "houdini.h"
 
+#define BUFFER_SIZE 100
+
 // Functions to convert cmark_nodes to XML strings.
 
 static void escape_xml(cmark_strbuf *dest, const unsigned char *source,
@@ -34,7 +36,6 @@ static int S_render_node(cmark_node *node, cmark_event_type ev_type,
   bool literal = false;
   cmark_delim_type delim;
   bool entering = (ev_type == CMARK_EVENT_ENTER);
-  const size_t BUFFER_SIZE = 100;
   char buffer[BUFFER_SIZE];
 
   if (entering) {

--- a/tools/appveyor-build.bat
+++ b/tools/appveyor-build.bat
@@ -1,0 +1,13 @@
+@echo off
+
+if "%MSVC_VERSION%" == "10" goto msvc10
+
+call "C:\Program Files (x86)\Microsoft Visual Studio %MSVC_VERSION%.0\VC\vcvarsall.bat" amd64
+goto build
+
+:msvc10
+call "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x64
+
+:build
+nmake
+


### PR DESCRIPTION
Under MSVC, we used to compile in C++ mode to get some C99 features
like mixing declarations and code. With newer MSVC versions, it's
possible to build in plain C mode.