### PR TITLE
Add library option to render softbreaks as spaces

### DIFF
--- a/api_test/main.c
+++ b/api_test/main.c
@@ -788,6 +788,11 @@ static void line_endings(test_batch_runner *runner) {
   STR_EQ(runner, html, "<p>line<br />\nline</p>\n",
          "crlf endings with CMARK_OPT_HARDBREAKS");
   free(html);
+  html = cmark_markdown_to_html(crlf_lines, sizeof(crlf_lines) - 1,
+                                CMARK_OPT_DEFAULT | CMARK_OPT_NOBREAKS);
+  STR_EQ(runner, html, "<p>line line</p>\n",
+         "crlf endings with CMARK_OPT_NOBREAKS");
+  free(html);
 
   static const char no_line_ending[] = "```\nline\n```";
   html = cmark_markdown_to_html(no_line_ending, sizeof(no_line_ending) - 1,

--- a/src/cmark.h
+++ b/src/cmark.h
@@ -519,7 +519,7 @@ char *cmark_render_latex(cmark_node *root, int options, int width);
  */
 #define CMARK_OPT_SAFE (1 << 3)
 
-/** Render `softbreak` elements as spaces.
+/** Render `softbreak` elements as spaces (HTML only).
  */
 #define CMARK_OPT_NOBREAKS (1 << 4)
 

--- a/src/cmark.h
+++ b/src/cmark.h
@@ -519,6 +519,10 @@ char *cmark_render_latex(cmark_node *root, int options, int width);
  */
 #define CMARK_OPT_SAFE (1 << 3)
 
+/** Render `softbreak` elements as spaces.
+ */
+#define CMARK_OPT_NOBREAKS (1 << 4)
+
 /**
  * ### Options affecting parsing
  */

--- a/src/html.c
+++ b/src/html.c
@@ -228,6 +228,8 @@ static int S_render_node(cmark_node *node, cmark_event_type ev_type,
   case CMARK_NODE_SOFTBREAK:
     if (options & CMARK_OPT_HARDBREAKS) {
       cmark_strbuf_puts(html, "<br />\n");
+    } else if (options & CMARK_OPT_NOBREAKS) {
+      cmark_strbuf_putc(html, ' ');
     } else {
       cmark_strbuf_putc(html, '\n');
     }


### PR DESCRIPTION
1. Option name was chosen to avoid confusion with “two spaces at the end” feature.

2. `make man/man3/cmark.3` produced extra non-related changes, so I did not do it.

3. There are two places I did not touch regarding this pull request: `src/main.c` and `src/commonmark.c` (I'm not familiar with their code, as I don't use them, so I can't decide how they should behave now).