### PR TITLE
Open files in binary mode

### DIFF
--- a/man/man3/cmark.3
+++ b/man/man3/cmark.3
@@ -543,7 +543,7 @@ Streaming interface:
 .nf
 \f[C]
 cmark_parser *parser = cmark_parser_new(CMARK_OPT_DEFAULT);
-FILE *fp = fopen("myfile.md", "r");
+FILE *fp = fopen("myfile.md", "rb");
 while ((bytes = fread(buffer, 1, sizeof(buffer), fp)) > 0) {
 	   cmark_parser_feed(parser, buffer, bytes);
 	   if (bytes < sizeof(buffer)) {

--- a/src/cmark.h
+++ b/src/cmark.h
@@ -418,7 +418,7 @@ CMARK_EXPORT void cmark_consolidate_text_nodes(cmark_node *root);
  * Streaming interface:
  *
  *     cmark_parser *parser = cmark_parser_new(CMARK_OPT_DEFAULT);
- *     FILE *fp = fopen("myfile.md", "r");
+ *     FILE *fp = fopen("myfile.md", "rb");
  *     while ((bytes = fread(buffer, 1, sizeof(buffer), fp)) > 0) {
  *     	   cmark_parser_feed(parser, buffer, bytes);
  *     	   if (bytes < sizeof(buffer)) {

--- a/src/main.c
+++ b/src/main.c
@@ -145,7 +145,7 @@ int main(int argc, char *argv[]) {
 
   parser = cmark_parser_new(options);
   for (i = 0; i < numfps; i++) {
-    FILE *fp = fopen(argv[files[i]], "r");
+    FILE *fp = fopen(argv[files[i]], "rb");
     if (fp == NULL) {
       fprintf(stderr, "Error opening file %s: %s\n", argv[files[i]],
               strerror(errno));


### PR DESCRIPTION
Now that cmark supports different line endings, files must be openend
in binary mode on Windows.

Fixes issue #113.