### PR TITLE
Set stdin to binary mode on Windows

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -75,6 +75,7 @@ int main(int argc, char *argv[]) {
   int options = CMARK_OPT_DEFAULT;
 
 #if defined(_WIN32) && !defined(__CYGWIN__)
+  _setmode(_fileno(stdin), _O_BINARY);
   _setmode(_fileno(stdout), _O_BINARY);
 #endif
 


### PR DESCRIPTION
Fixes EOLs when reading from stdin.

Fully fixes issue #113.