### PR TITLE
Fix tests under MinGW

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,9 +13,9 @@ add_test(NAME api_test COMMAND api_test)
 
 if (WIN32)
   file(TO_NATIVE_PATH ${CMAKE_BINARY_DIR}/src WIN_DLL_DIR)
-  set_tests_properties(api_test PROPERTIES
-    ENVIRONMENT "PATH=${WIN_DLL_DIR};$ENV{PATH}"
-    )
+  set(NEWPATH "${WIN_DLL_DIR};$ENV{PATH}")
+  string(REPLACE ";" "\\;" NEWPATH "${NEWPATH}")
+  set_tests_properties(api_test PROPERTIES ENVIRONMENT "PATH=${NEWPATH}")
   set(ROUNDTRIP,"${CMAKE_CURRENT_SOURCE_DIR}/roundtrip.bat")
 else(WIN32)
   set(ROUNDTRIP,"${CMAKE_CURRENT_SOURCE_DIR}/roundtrip.sh")

--- a/test/cmark.py
+++ b/test/cmark.py
@@ -24,15 +24,18 @@ class CMark:
         else:
             sysname = platform.system()
             if sysname == 'Darwin':
-                libname = "libcmark.dylib"
+                libnames = [ "libcmark.dylib" ]
             elif sysname == 'Windows':
-                libname = "cmark.dll"
+                libnames = [ "cmark.dll", "libcmark.dll" ]
             else:
-                libname = "libcmark.so"
-            if library_dir:
-                libpath = os.path.join(library_dir, libname)
-            else:
-                libpath = os.path.join("build", "src", libname)
+                libnames = [ "libcmark.so" ]
+            if not library_dir:
+                library_dir = os.path.join("build", "src")
+            for libname in libnames:
+                candidate = os.path.join(library_dir, libname)
+                if os.path.isfile(candidate):
+                    libpath = candidate
+                    break
             cmark = CDLL(libpath)
             markdown = cmark.cmark_markdown_to_html
             markdown.restype = c_char_p


### PR DESCRIPTION
- Fix PATH for api_test, see:
  https://cmake.org/pipermail/cmake/2009-May/029423.html
- DLL is named libcmark.dll under MinGW.