### PR TITLE
Fix character type detection in commonmark.c

### DIFF
--- a/src/cmark_ctype.c
+++ b/src/cmark_ctype.c
@@ -40,3 +40,5 @@ int cmark_isalnum(char c) {
 }
 
 int cmark_isdigit(char c) { return cmark_ctype_class[(uint8_t)c] == 3; }
+
+int cmark_isalpha(char c) { return cmark_ctype_class[(uint8_t)c] == 4; }

--- a/src/cmark_ctype.h
+++ b/src/cmark_ctype.h
@@ -17,6 +17,8 @@ int cmark_isalnum(char c);
 
 int cmark_isdigit(char c);
 
+int cmark_isalpha(char c);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/latex.c
+++ b/src/latex.c
@@ -2,7 +2,6 @@
 #include <stdio.h>
 #include <string.h>
 #include <assert.h>
-#include <ctype.h>
 
 #include "config.h"
 #include "cmark.h"


### PR DESCRIPTION
- Implement cmark_isalpha.
- Check for ASCII character before implicit cast to char.
- Use internal ctype functions in commonmark.c.

Fixes test failures on Windows and undefined behavior.