### PR TITLE
Fix chunk_set_cstr with suffix of current string

### DIFF
--- a/api_test/main.c
+++ b/api_test/main.c
@@ -171,7 +171,13 @@ static void accessors(test_batch_runner *runner) {
   OK(runner, cmark_node_set_url(link, "URL"), "set_url");
   OK(runner, cmark_node_set_title(link, "TITLE"), "set_title");
 
-  OK(runner, cmark_node_set_literal(string, "LINK"), "set_literal string");
+  OK(runner, cmark_node_set_literal(string, "prefix-LINK"),
+     "set_literal string");
+
+  // Set literal to suffix of itself (issue #139).
+  const char *literal = cmark_node_get_literal(string);
+  OK(runner, cmark_node_set_literal(string, literal + sizeof("prefix")),
+     "set_literal suffix");
 
   char *rendered_html = cmark_render_html(doc, CMARK_OPT_DEFAULT);
   static const char expected_html[] =

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -77,9 +77,7 @@ static CMARK_INLINE const char *cmark_chunk_to_cstr(cmark_mem *mem,
 
 static CMARK_INLINE void cmark_chunk_set_cstr(cmark_mem *mem, cmark_chunk *c,
                                               const char *str) {
-  if (c->alloc) {
-    mem->free(c->data);
-  }
+  unsigned char *old = c->alloc ? c->data : NULL;
   if (str == NULL) {
     c->len = 0;
     c->data = NULL;
@@ -89,6 +87,9 @@ static CMARK_INLINE void cmark_chunk_set_cstr(cmark_mem *mem, cmark_chunk *c,
     c->data = (unsigned char *)mem->calloc(c->len + 1, 1);
     c->alloc = 1;
     memcpy(c->data, str, c->len + 1);
+  }
+  if (old != NULL) {
+    mem->free(old);
   }
 }
 


### PR DESCRIPTION
It's possible that cmark_chunk_set_cstr is called with a substring
(suffix) of the current string. Delay freeing of the chunk content
to handle this case correctly.

Fixes issue #139.