### PR TITLE
Fix nullary function declarations in cmark.h

### DIFF
--- a/src/cmark.h
+++ b/src/cmark.h
@@ -590,13 +590,13 @@ char *cmark_render_latex(cmark_node *root, int options, int width);
  * In hexadecimal format, the number 0x010203 represents version 1.2.3.
  */
 CMARK_EXPORT
-int cmark_version();
+int cmark_version(void);
 
 /** The library version string for runtime checks. Also available as
  * macro CMARK_VERSION_STRING for compile time checks.
  */
 CMARK_EXPORT
-const char *cmark_version_string();
+const char *cmark_version_string(void);
 
 /** # AUTHORS
  *


### PR DESCRIPTION
Fixes strict prototypes warnings.