### PR TITLE
autolink scheme can contain digits

### DIFF
--- a/src/scanners.re
+++ b/src/scanners.re
@@ -71,7 +71,7 @@ bufsize_t _scan_at(bufsize_t (*scanner)(const unsigned char *), cmark_chunk *c, 
   in_single_quotes = ['] (escaped_char|[^'\x00])* ['];
   in_parens        = [(] (escaped_char|[^)\x00])* [)];
 
-  scheme           = [A-Za-z ][A-Za-z.+-]{1,31};
+  scheme           = [A-Za-z ][A-Za-z0-9.+-]{1,31};
 */
 
 // Try to match a scheme including colon.


### PR DESCRIPTION
According to the specs: http://spec.commonmark.org/0.26/#scheme

> For purposes of this spec, a scheme is any sequence of 2–32 characters 
> beginning with an ASCII letter and followed by any combination of ASCII
> letters, digits, or the symbols plus (”+”), period (”.”), or hyphen (”-”).