### PR TITLE
Use cmark_mem to free where used to alloc

### DIFF
--- a/src/blocks.c
+++ b/src/blocks.c
@@ -989,7 +989,7 @@ static void open_new_blocks(cmark_parser *parser, cmark_node **container,
                              parser->first_nonspace + 1);
       /* TODO: static */
       memcpy(&((*container)->as.list), data, sizeof(*data));
-      free(data);
+      parser->mem->free(data);
     } else if (indented && !maybe_lazy && !parser->blank) {
       S_advance_offset(parser, input, CODE_INDENT, true);
       *container = add_child(parser, *container, CMARK_NODE_CODE_BLOCK,

--- a/src/inlines.c
+++ b/src/inlines.c
@@ -353,7 +353,7 @@ static void remove_delimiter(subject *subj, delimiter *delim) {
   if (delim->previous != NULL) {
     delim->previous->next = delim->next;
   }
-  free(delim);
+  subj->mem->free(delim);
 }
 
 static void pop_bracket(subject *subj) {
@@ -362,7 +362,7 @@ static void pop_bracket(subject *subj) {
     return;
   b = subj->last_bracket;
   subj->last_bracket = subj->last_bracket->previous;
-  free(b);
+  subj->mem->free(b);
 }
 
 static void push_delimiter(subject *subj, unsigned char c, bool can_open,

--- a/src/references.c
+++ b/src/references.c
@@ -46,7 +46,7 @@ static unsigned char *normalize_reference(cmark_mem *mem, cmark_chunk *ref) {
   assert(result);
 
   if (result[0] == '\0') {
-    free(result);
+    mem->free(result);
     return NULL;
   }
 
@@ -114,7 +114,7 @@ cmark_reference *cmark_reference_lookup(cmark_reference_map *map,
     ref = ref->next;
   }
 
-  free(norm);
+  map->mem->free(norm);
   return ref;
 }
 
@@ -135,7 +135,7 @@ void cmark_reference_map_free(cmark_reference_map *map) {
     }
   }
 
-  free(map);
+  map->mem->free(map);
 }
 
 cmark_reference_map *cmark_reference_map_new(cmark_mem *mem) {


### PR DESCRIPTION
In a few places we don't use the `cmark_mem`'s `free` function when we used its `calloc`/`realloc`. This could bite someone using a custom allocator.