### PR TITLE
Fix NUL-LF sequence lex

### DIFF
--- a/api_test/main.c
+++ b/api_test/main.c
@@ -732,6 +732,13 @@ static void utf8(test_batch_runner *runner) {
       string_with_null, sizeof(string_with_null) - 1, CMARK_OPT_DEFAULT);
   STR_EQ(runner, html, "<p>((((" UTF8_REPL "))))</p>\n", "utf8 with U+0000");
   free(html);
+
+  // Test NUL followed by newline
+  static const char string_with_nul_lf[] = "```\n\0\n```\n";
+  html = cmark_markdown_to_html(
+      string_with_nul_lf, sizeof(string_with_nul_lf) - 1, CMARK_OPT_DEFAULT);
+  STR_EQ(runner, html, "<pre><code>\xef\xbf\xbd\n</code></pre>\n", "utf8 with \\0\\n");
+  free(html);
 }
 
 static void test_char(test_batch_runner *runner, int valid, const char *utf8,

--- a/src/blocks.c
+++ b/src/blocks.c
@@ -563,7 +563,6 @@ static void S_parser_feed(cmark_parser *parser, const unsigned char *buffer,
         cmark_strbuf_put(&parser->linebuf, buffer, chunk_len);
         // add replacement character
         cmark_strbuf_put(&parser->linebuf, repl, 3);
-        chunk_len += 1; // so we advance the buffer past NULL
       } else {
         cmark_strbuf_put(&parser->linebuf, buffer, chunk_len);
       }
@@ -576,7 +575,9 @@ static void S_parser_feed(cmark_parser *parser, const unsigned char *buffer,
       if (buffer == end)
         parser->last_buffer_ended_with_cr = true;
     }
-    if (buffer < end && *buffer == '\n')
+    if (buffer < end && *buffer == '\0')
+      buffer++;
+    else if (buffer < end && *buffer == '\n')
       buffer++;
   }
 }


### PR DESCRIPTION
Fixes #159.

If we hit a NUL, we advance past it. But then we advance past any LF or CR-LF, assuming we're at the end of a line and just need to push past the newline that broke us from the loop.