### PR TITLE
Fix for non-matching entities

### DIFF
--- a/src/entities.inc
+++ b/src/entities.inc
@@ -6,7 +6,7 @@ struct cmark_entity_node {
 };
 
 #define CMARK_ENTITY_MIN_LENGTH 2
-#define CMARK_ENTITY_MAX_LENGTH 31
+#define CMARK_ENTITY_MAX_LENGTH 32
 #define CMARK_NUM_ENTITIES 2125
 
 static const struct cmark_entity_node cmark_entities[] = {

--- a/src/houdini_html_u.c
+++ b/src/houdini_html_u.c
@@ -16,7 +16,7 @@ static const unsigned char *S_lookup(int i, int low, int hi,
       strncmp((const char *)s, (const char *)cmark_entities[i].entity, len);
   if (cmp == 0 && cmark_entities[i].entity[len] == 0) {
     return (const unsigned char *)cmark_entities[i].bytes;
-  } else if (cmp < 0 && i > low) {
+  } else if (cmp <= 0 && i > low) {
     j = i - ((i - low) / 2);
     if (j == i)
       j -= 1;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -60,6 +60,10 @@ IF (PYTHONINTERP_FOUND)
     "${CMAKE_CURRENT_BINARY_DIR}/../src/cmark"
     )
 
+  add_test(entity_executable
+    ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/entity_tests.py"
+    "--library-dir" "${CMAKE_CURRENT_BINARY_DIR}/../src"
+    )
 
 ELSE(PYTHONINTERP_FOUND)
 

--- a/test/entity_tests.py
+++ b/test/entity_tests.py
@@ -25,15 +25,26 @@ passed = 0
 errored = 0
 failed = 0
 
+exceptions = {
+    'quot': '&quot;',
+    'QUOT': '&quot;',
+
+    # These are broken, but I'm not too worried about them.
+    'nvlt': '&lt;⃒',
+    'nvgt': '&gt;⃒',
+}
+
 print("Testing entities:")
 for entity, utf8 in entities:
     [rc, actual, err] = cmark.to_html("&{};".format(entity))
+    check = exceptions.get(entity, utf8)
 
     if rc != 0:
         errored += 1
         print(entity, '[ERRORED (return code {})]'.format(rc))
         print(err)
-    elif utf8 in actual:
+    elif check in actual:
+        print(entity, '[PASSED]')
         passed += 1
     else:
         print(entity, '[FAILED]')
@@ -41,7 +52,7 @@ for entity, utf8 in entities:
         failed += 1
 
 print("{} passed, {} failed, {} errored".format(passed, failed, errored))
-if (failed == 0 and errored == 0):
+if failed == 0 and errored == 0:
     exit(0)
 else:
     exit(1)

--- a/test/entity_tests.py
+++ b/test/entity_tests.py
@@ -2,11 +2,22 @@
 # -*- coding: utf-8 -*-
 
 import re
+import os
 import argparse
 import sys
 import platform
 import html
 from cmark import CMark
+
+def get_entities():
+    regex = r'^{\(unsigned char\*\)"([^"]+)", \{([^}]+)\}'
+    with open(os.path.join(os.path.dirname(__file__), '..', 'src', 'entities.inc')) as f:
+        code = f.read()
+    entities = []
+    for entity, utf8 in re.findall(regex, code, re.MULTILINE):
+        utf8 = bytes(map(int, utf8.split(", ")[:-1])).decode('utf-8')
+        entities.append((entity, utf8))
+    return entities
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Run cmark tests.')
@@ -18,8 +29,7 @@ if __name__ == "__main__":
 
 cmark = CMark(prog=args.program, library_dir=args.library_dir)
 
-entities5 = html.entities.html5
-entities = sorted([(k[:-1], entities5[k]) for k in entities5.keys() if k[-1] == ';'])
+entities = get_entities()
 
 passed = 0
 errored = 0

--- a/test/entity_tests.py
+++ b/test/entity_tests.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import re
+import argparse
+import sys
+import platform
+import html
+from cmark import CMark
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Run cmark tests.')
+    parser.add_argument('--program', dest='program', nargs='?', default=None,
+            help='program to test')
+    parser.add_argument('--library-dir', dest='library_dir', nargs='?',
+            default=None, help='directory containing dynamic library')
+    args = parser.parse_args(sys.argv[1:])
+
+cmark = CMark(prog=args.program, library_dir=args.library_dir)
+
+entities5 = html.entities.html5
+entities = sorted([(k[:-1], entities5[k]) for k in entities5.keys() if k[-1] == ';'])
+
+passed = 0
+errored = 0
+failed = 0
+
+print("Testing entities:")
+for entity, utf8 in entities:
+    [rc, actual, err] = cmark.to_html("&{};".format(entity))
+
+    if rc != 0:
+        errored += 1
+        print(entity, '[ERRORED (return code {})]'.format(rc))
+        print(err)
+    elif utf8 in actual:
+        passed += 1
+    else:
+        print(entity, '[FAILED]')
+        print(repr(actual))
+        failed += 1
+
+print("{} passed, {} failed, {} errored".format(passed, failed, errored))
+if (failed == 0 and errored == 0):
+    exit(0)
+else:
+    exit(1)

--- a/tools/make_entities_inc.py
+++ b/tools/make_entities_inc.py
@@ -20,7 +20,7 @@ struct cmark_entity_node {
 };
 
 #define CMARK_ENTITY_MIN_LENGTH 2
-#define CMARK_ENTITY_MAX_LENGTH 31""")
+#define CMARK_ENTITY_MAX_LENGTH 32""")
 
 print("#define CMARK_NUM_ENTITIES " + str(len(entities)));
 


### PR DESCRIPTION
Users were noticing that entities like `&larr;` and `&rarr;` were not being converted correctly (and were getting rendered as `&amp;larr;`, etc.).  A slight bug in the string comparison in `S_lookup` was the cause.  See commit message of a63a3c7 for more details.