### PR TITLE
Remove unnecessary cmake_minimum_required

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 2.8)
 set(LIBRARY "libcmark")
 set(STATICLIBRARY "libcmark_static")
 set(HEADERS


### PR DESCRIPTION
Top-level CMakeLists already includes this, and uses a different version number anyways