### PR TITLE
Correctly initialize chunk in S_process_line

### DIFF
--- a/src/blocks.c
+++ b/src/blocks.c
@@ -1157,6 +1157,7 @@ static void S_process_line(cmark_parser *parser, const unsigned char *buffer,
 
   input.data = parser->curline.ptr;
   input.len = parser->curline.size;
+  input.alloc = 0;
 
   parser->line_number++;
 

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -37,6 +37,8 @@ static CMARK_INLINE void cmark_chunk_ltrim(cmark_chunk *c) {
 }
 
 static CMARK_INLINE void cmark_chunk_rtrim(cmark_chunk *c) {
+  assert(!c->alloc);
+
   while (c->len > 0) {
     if (!cmark_isspace(c->data[c->len - 1]))
       break;


### PR DESCRIPTION
The `alloc` member wasn't initialized.

This also allows to add an assertion in `chunk_rtrim` which doesn't
work for alloced chunks.