### PR TITLE
wrapper.py: remove unused (and faulty) libc instantiation

### DIFF
--- a/wrappers/wrapper.py
+++ b/wrappers/wrapper.py
@@ -6,13 +6,6 @@ import platform
 
 c_object_p = POINTER(c_void_p)
 
-sysname = platform.system()
-
-if sysname == 'Windows':
-    libc = CDLL('msvcrt.dll')
-else:
-    libc = CDLL('libc.so.6')
-
 if sys.version_info[0] > 2:
     def bytes_and_length(text):
         if type(text) == str:


### PR DESCRIPTION
As explained in #169 this was a remnant from previous attempts at memory usage correctness, sorry about that. Travis succeeding simply meant on its platform instantiating the libc DLL this way was working.