### PR TITLE
CMake impovement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,9 +22,11 @@ set(PROJECT_VERSION_PATCH 1)
 set(PROJECT_VERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH} )
 
 option(CMARK_TESTS "Build cmark tests and enable testing" ON)
+option(CMARK_STATIC "Build static libcmark library" ON)
+option(CMARK_SHARED "Build shared libcmark library" ON)
 
 add_subdirectory(src)
-if(CMARK_TESTS)
+if(CMARK_TESTS AND CMARK_SHARED)
   add_subdirectory(api_test)
 endif()
 add_subdirectory(man)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,15 +49,6 @@ set(PROGRAM_SOURCES
   main.c
   )
 
-# We make LIB_INSTALL_DIR configurable rather than
-# hard-coding lib, because on some OSes different locations
-# are used for different architectures (e.g. /usr/lib64 on
-# 64-bit Fedora).
-if(NOT LIB_INSTALL_DIR)
-  set(LIB_INSTALL_DIR "lib" CACHE STRING
-  "Set the installation directory for libraries." FORCE)
-endif(NOT LIB_INSTALL_DIR)
-
 include_directories(. ${CMAKE_CURRENT_BINARY_DIR})
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmark_version.h.in
@@ -66,7 +57,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmark_version.h.in
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/libcmark.pc.in
   ${CMAKE_CURRENT_BINARY_DIR}/libcmark.pc @ONLY)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libcmark.pc
-  DESTINATION ${LIB_INSTALL_DIR}/pkgconfig)
+  DESTINATION lib${LIB_SUFFIX}/pkgconfig)
 
 include (GenerateExportHeader)
 
@@ -131,8 +122,8 @@ include (InstallRequiredSystemLibraries)
 install(TARGETS ${PROGRAM} ${LIBRARY} ${STATICLIBRARY}
   EXPORT cmark
   RUNTIME DESTINATION bin
-  LIBRARY DESTINATION ${LIB_INSTALL_DIR}
-  ARCHIVE DESTINATION ${LIB_INSTALL_DIR}
+  LIBRARY DESTINATION lib${LIB_SUFFIX}
+  ARCHIVE DESTINATION lib${LIB_SUFFIX}
   )
 
 install(FILES
@@ -142,7 +133,7 @@ install(FILES
   DESTINATION include
   )
 
-install(EXPORT cmark DESTINATION ${LIB_INSTALL_DIR}/cmake)
+install(EXPORT cmark DESTINATION lib${LIB_SUFFIX}/cmake)
 
 # Feature tests
 include(CheckIncludeFile)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -54,11 +54,6 @@ include_directories(. ${CMAKE_CURRENT_BINARY_DIR})
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmark_version.h.in
   ${CMAKE_CURRENT_BINARY_DIR}/cmark_version.h)
 
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/libcmark.pc.in
-  ${CMAKE_CURRENT_BINARY_DIR}/libcmark.pc @ONLY)
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libcmark.pc
-  DESTINATION lib${LIB_SUFFIX}/pkgconfig)
-
 include (GenerateExportHeader)
 
 add_executable(${PROGRAM} ${PROGRAM_SOURCES})
@@ -82,35 +77,44 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR ${CMAKE_C_COMPILER_ID} STREQUAL "Clang")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fvisibility=hidden")
 endif ()
 
-add_library(${LIBRARY} SHARED ${LIBRARY_SOURCES})
-add_library(${STATICLIBRARY} STATIC ${LIBRARY_SOURCES})
-# Include minor version and patch level in soname for now.
-set_target_properties(${LIBRARY} PROPERTIES
-  OUTPUT_NAME "cmark"
-  SOVERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}
-  VERSION ${PROJECT_VERSION})
-set_target_properties(${STATICLIBRARY} PROPERTIES
-  COMPILE_FLAGS -DCMARK_STATIC_DEFINE
-  POSITION_INDEPENDENT_CODE ON)
-
-if (MSVC)
-  set_target_properties(${STATICLIBRARY} PROPERTIES
-    OUTPUT_NAME "cmark_static"
-    VERSION ${PROJECT_VERSION})
-else()
-  set_target_properties(${STATICLIBRARY} PROPERTIES
+if (CMARK_SHARED)
+  add_library(${LIBRARY} SHARED ${LIBRARY_SOURCES})
+  # Include minor version and patch level in soname for now.
+  set_target_properties(${LIBRARY} PROPERTIES
     OUTPUT_NAME "cmark"
+    SOVERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}
     VERSION ${PROJECT_VERSION})
-endif(MSVC)
 
-set_property(TARGET ${LIBRARY}
-  APPEND PROPERTY MACOSX_RPATH true)
+  set_property(TARGET ${LIBRARY}
+    APPEND PROPERTY MACOSX_RPATH true)
 
-# Avoid name clash between PROGRAM and LIBRARY pdb files.
-set_target_properties(${LIBRARY} PROPERTIES PDB_NAME cmark_dll)
+  # Avoid name clash between PROGRAM and LIBRARY pdb files.
+  set_target_properties(${LIBRARY} PROPERTIES PDB_NAME cmark_dll)
 
-generate_export_header(${LIBRARY}
+  generate_export_header(${LIBRARY}
     BASE_NAME ${PROJECT_NAME})
+
+  list(APPEND CMARK_INSTALL ${LIBRARY})
+endif()
+
+if (CMARK_STATIC)
+  add_library(${STATICLIBRARY} STATIC ${LIBRARY_SOURCES})
+  set_target_properties(${STATICLIBRARY} PROPERTIES
+    COMPILE_FLAGS -DCMARK_STATIC_DEFINE
+    POSITION_INDEPENDENT_CODE ON)
+
+  if (MSVC)
+    set_target_properties(${STATICLIBRARY} PROPERTIES
+      OUTPUT_NAME "cmark_static"
+      VERSION ${PROJECT_VERSION})
+  else()
+    set_target_properties(${STATICLIBRARY} PROPERTIES
+      OUTPUT_NAME "cmark"
+      VERSION ${PROJECT_VERSION})
+  endif(MSVC)
+
+  list(APPEND CMARK_INSTALL ${STATICLIBRARY})
+endif()
 
 if (MSVC)
   set_property(TARGET ${PROGRAM}
@@ -118,22 +122,30 @@ if (MSVC)
 endif(MSVC)
 
 set(CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_NO_WARNINGS ON)
+
 include (InstallRequiredSystemLibraries)
-install(TARGETS ${PROGRAM} ${LIBRARY} ${STATICLIBRARY}
+install(TARGETS ${PROGRAM} ${CMARK_INSTALL}
   EXPORT cmark
   RUNTIME DESTINATION bin
   LIBRARY DESTINATION lib${LIB_SUFFIX}
   ARCHIVE DESTINATION lib${LIB_SUFFIX}
   )
 
-install(FILES
-  cmark.h
-  ${CMAKE_CURRENT_BINARY_DIR}/cmark_export.h
-  ${CMAKE_CURRENT_BINARY_DIR}/cmark_version.h
-  DESTINATION include
-  )
+if(CMARK_SHARED OR CMARK_STATIC)
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/libcmark.pc.in
+    ${CMAKE_CURRENT_BINARY_DIR}/libcmark.pc @ONLY)
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libcmark.pc
+    DESTINATION lib${LIB_SUFFIX}/pkgconfig)
 
-install(EXPORT cmark DESTINATION lib${LIB_SUFFIX}/cmake)
+  install(FILES
+    cmark.h
+    ${CMAKE_CURRENT_BINARY_DIR}/cmark_export.h
+    ${CMAKE_CURRENT_BINARY_DIR}/cmark_version.h
+    DESTINATION include
+    )
+
+  install(EXPORT cmark DESTINATION lib${LIB_SUFFIX}/cmake)
+endif()
 
 # Feature tests
 include(CheckIncludeFile)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,7 +9,9 @@ else(SPEC_TESTS)
   find_package(PythonInterp 3)
 endif(SPEC_TESTS)
 
-add_test(NAME api_test COMMAND api_test)
+if (CMARK_SHARED)
+  add_test(NAME api_test COMMAND api_test)
+endif()
 
 if (WIN32)
   file(TO_NATIVE_PATH ${CMAKE_BINARY_DIR}/src WIN_DLL_DIR)
@@ -28,15 +30,30 @@ IF (PYTHONINTERP_FOUND)
     "${CMAKE_CURRENT_SOURCE_DIR}/normalize.py"
     )
 
-  add_test(spectest_library
-    ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/spec_tests.py" "--no-normalize" "--spec"
-    "${CMAKE_CURRENT_SOURCE_DIR}/spec.txt" "--library-dir" "${CMAKE_CURRENT_BINARY_DIR}/../src"
-    )
+  if (CMARK_SHARED)
+    add_test(spectest_library
+      ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/spec_tests.py" "--no-normalize" "--spec"
+      "${CMAKE_CURRENT_SOURCE_DIR}/spec.txt" "--library-dir" "${CMAKE_CURRENT_BINARY_DIR}/../src"
+      )
 
-  add_test(pathological_tests_library
-    ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/pathological_tests.py"
-    "--library-dir" "${CMAKE_CURRENT_BINARY_DIR}/../src"
-    )
+    add_test(pathological_tests_library
+      ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/pathological_tests.py"
+      "--library-dir" "${CMAKE_CURRENT_BINARY_DIR}/../src"
+      )
+
+    add_test(roundtriptest_executable
+      ${PYTHON_EXECUTABLE}
+      "${CMAKE_CURRENT_SOURCE_DIR}/roundtrip_tests.py"
+      "--spec" "${CMAKE_CURRENT_SOURCE_DIR}/spec.txt"
+      "--library-dir" "${CMAKE_CURRENT_BINARY_DIR}/../src"
+      )
+
+    add_test(entity_executable
+      ${PYTHON_EXECUTABLE}
+      "${CMAKE_CURRENT_SOURCE_DIR}/entity_tests.py"
+      "--library-dir" "${CMAKE_CURRENT_BINARY_DIR}/../src"
+      )
+  endif()
 
   add_test(spectest_executable
     ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/spec_tests.py" "--no-normalize" "--spec" "${CMAKE_CURRENT_SOURCE_DIR}/spec.txt" "--program" "${CMAKE_CURRENT_BINARY_DIR}/../src/cmark"
@@ -46,23 +63,11 @@ IF (PYTHONINTERP_FOUND)
     ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/spec_tests.py" "--no-normalize" "--spec" "${CMAKE_CURRENT_SOURCE_DIR}/smart_punct.txt" "--program" "${CMAKE_CURRENT_BINARY_DIR}/../src/cmark --smart"
     )
 
-  add_test(roundtriptest_executable
-    ${PYTHON_EXECUTABLE}
-    "${CMAKE_CURRENT_SOURCE_DIR}/roundtrip_tests.py"
-    "--spec" "${CMAKE_CURRENT_SOURCE_DIR}/spec.txt"
-    "--library-dir" "${CMAKE_CURRENT_BINARY_DIR}/../src"
-    )
-
   add_test(regressiontest_executable
     ${PYTHON_EXECUTABLE}
     "${CMAKE_CURRENT_SOURCE_DIR}/spec_tests.py" "--no-normalize" "--spec"
     "${CMAKE_CURRENT_SOURCE_DIR}/regression.txt" "--program"
     "${CMAKE_CURRENT_BINARY_DIR}/../src/cmark"
-    )
-
-  add_test(entity_executable
-    ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/entity_tests.py"
-    "--library-dir" "${CMAKE_CURRENT_BINARY_DIR}/../src"
     )
 
 ELSE(PYTHONINTERP_FOUND)


### PR DESCRIPTION
- Added support for built-in ${LIB_SIFFIX} feature, so CMake will automatically generate correct path for 32/64-bit environment.
- Making shared and static libraries optional to compile and install via -DCMARK_SHARED=ON/OFF and -DCMARK_STATIC=ON/OFF options.  By default both targets are set as enabled (previous behavior). 