### PR TITLE
Initialise openers_bottom correctly

### DIFF
--- a/src/inlines.c
+++ b/src/inlines.c
@@ -520,6 +520,7 @@ static void process_emphasis(subject *subj, delimiter *stack_bottom) {
   int i;
 
   // initialize openers_bottom:
+  memset(&openers_bottom, 0, sizeof(openers_bottom));
   for (i=0; i < 3; i++) {
     openers_bottom[i]['*'] = stack_bottom;
     openers_bottom[i]['_'] = stack_bottom;


### PR DESCRIPTION
The array is uninitialised; valgrind caught it as follows:

```
==3119== Conditional jump or move depends on uninitialised value(s)
==3119==    at 0x4E4C64F: process_emphasis (inlines.c:552)
==3119==    by 0x4E4DFBB: cmark_parse_inlines (inlines.c:1211)
==3119==    by 0x4E48C93: process_inlines (blocks.c:418)
==3119==    by 0x4E4907C: finalize_document (blocks.c:531)
==3119==    by 0x4E4ADF1: cmark_parser_finish (blocks.c:1305)
==3119==    by 0x4038A6: main (main.c:239)
==3119== 
```