### PR TITLE
Fixes for the LaTeX renderer

### DIFF
--- a/src/latex.c
+++ b/src/latex.c
@@ -391,7 +391,7 @@ static int S_render_node(cmark_renderer *renderer, cmark_node *node,
         LIT("\\url{");
         OUT(url, false, URL);
         LIT("}");
-        return 0;
+        return 0; // Don't process further nodes to avoid double-rendering artefacts
       case EMAIL_AUTOLINK:
         LIT("\\href{");
         OUT(url, false, URL);

--- a/src/latex.c
+++ b/src/latex.c
@@ -42,7 +42,7 @@ static CMARK_INLINE void outc(cmark_renderer *renderer, cmark_escaping escape,
     break;
   case 45:             // '-'
     if (nextc == 45) { // prevent ligature
-      cmark_render_ascii(renderer, "\\-");
+      cmark_render_ascii(renderer, "-{}");
     } else {
       cmark_render_ascii(renderer, "-");
     }

--- a/src/latex.c
+++ b/src/latex.c
@@ -389,7 +389,6 @@ static int S_render_node(cmark_renderer *renderer, cmark_node *node,
       switch (get_link_type(node)) {
       case URL_AUTOLINK:
         LIT("\\url{");
-        OUT(url, false, URL);
         break;
       case EMAIL_AUTOLINK:
         LIT("\\href{");

--- a/src/latex.c
+++ b/src/latex.c
@@ -389,7 +389,9 @@ static int S_render_node(cmark_renderer *renderer, cmark_node *node,
       switch (get_link_type(node)) {
       case URL_AUTOLINK:
         LIT("\\url{");
-        break;
+        OUT(url, false, URL);
+        LIT("}");
+        return 0;
       case EMAIL_AUTOLINK:
         LIT("\\href{");
         OUT(url, false, URL);


### PR DESCRIPTION
The first fix corrects ligature handling with dashes, (\- are manual hyphenations), the second fixes a double-output of urls.