### PR TITLE
libcmark.pc: use CMAKE_INSTALL_LIBDIR

### DIFF
--- a/src/libcmark.pc.in
+++ b/src/libcmark.pc.in
@@ -1,6 +1,6 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=@CMAKE_INSTALL_PREFIX@
-libdir=@CMAKE_INSTALL_PREFIX@/lib
+libdir=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@
 includedir=@CMAKE_INSTALL_PREFIX@/include
 
 Name: libcmark


### PR DESCRIPTION
needed for multilib distros like Fedora

See https://bugzilla.redhat.com/show_bug.cgi?id=1416426

Particularly with `pkgconf`.