### PR TITLE
Remove normalize as an option per #190

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,7 @@ $(ALLTESTS): $(SPEC)
 
 leakcheck: $(ALLTESTS)
 	for format in html man xml latex commonmark; do \
-	  for opts in "" "--smart" "--normalize"; do \
+	  for opts in "" "--smart"; do \
 	     echo "cmark -t $$format $$opts" ; \
 	     valgrind -q --leak-check=full --dsymutil=yes --error-exitcode=1 $(PROG) -t $$format $$opts $(ALLTESTS) >/dev/null || exit 1;\
           done; \

--- a/man/man3/cmark.3
+++ b/man/man3/cmark.3
@@ -1,4 +1,4 @@
-.TH cmark 3 "November 18, 2016" "LOCAL" "Library Functions Manual"
+.TH cmark 3 "May 05, 2017" "LOCAL" "Library Functions Manual"
 .SH
 NAME
 .PP
@@ -742,18 +742,6 @@ Render \f[C]softbreak\f[] elements as spaces.
 
 .SS
 Options affecting parsing
-
-.PP
-.nf
-\fC
-.RS 0n
-#define CMARK_OPT_NORMALIZE (1 << 8)
-.RE
-\f[]
-.fi
-
-.PP
-Normalize tree by consolidating adjacent text nodes.
 
 .PP
 .nf

--- a/src/blocks.c
+++ b/src/blocks.c
@@ -1192,9 +1192,7 @@ cmark_node *cmark_parser_finish(cmark_parser *parser) {
 
   finalize_document(parser);
 
-  if (parser->options & CMARK_OPT_NORMALIZE) {
-    cmark_consolidate_text_nodes(parser->root);
-  }
+  cmark_consolidate_text_nodes(parser->root);
 
   cmark_strbuf_free(&parser->curline);
 

--- a/src/cmark.h
+++ b/src/cmark.h
@@ -563,10 +563,6 @@ char *cmark_render_latex(cmark_node *root, int options, int width);
  * ### Options affecting parsing
  */
 
-/** Normalize tree by consolidating adjacent text nodes.
- */
-#define CMARK_OPT_NORMALIZE (1 << 8)
-
 /** Validate UTF-8 in the input before parsing, replacing illegal
  * sequences with the replacement character U+FFFD.
  */

--- a/src/main.c
+++ b/src/main.c
@@ -32,7 +32,6 @@ void print_usage() {
   printf("  --nobreaks       Render soft line breaks as spaces\n");
   printf("  --safe           Suppress raw HTML and dangerous URLs\n");
   printf("  --smart          Use smart punctuation\n");
-  printf("  --normalize      Consolidate adjacent text nodes\n");
   printf("  --help, -h       Print usage information\n");
   printf("  --version        Print version\n");
 }
@@ -99,8 +98,6 @@ int main(int argc, char *argv[]) {
       options |= CMARK_OPT_SMART;
     } else if (strcmp(argv[i], "--safe") == 0) {
       options |= CMARK_OPT_SAFE;
-    } else if (strcmp(argv[i], "--normalize") == 0) {
-      options |= CMARK_OPT_NORMALIZE;
     } else if (strcmp(argv[i], "--validate-utf8") == 0) {
       options |= CMARK_OPT_VALIDATE_UTF8;
     } else if ((strcmp(argv[i], "--help") == 0) ||


### PR DESCRIPTION
Always normalize, fixes #190. This ensures CommonMark roundtripping works as expected.

Should we shift the option constants `CMARK_OPT_VALIDATE_UTF8` and `CMARK_OPT_SMART` forward? Unclear.