### PR TITLE
Revert "Remove normalize as an option per #190"

### DIFF
--- a/man/man3/cmark.3
+++ b/man/man3/cmark.3
@@ -747,6 +747,18 @@ Options affecting parsing
 .nf
 \fC
 .RS 0n
+#define CMARK_OPT_NORMALIZE (1 << 8)
+.RE
+\f[]
+.fi
+
+.PP
+Legacy option (no effect).
+
+.PP
+.nf
+\fC
+.RS 0n
 #define CMARK_OPT_VALIDATE_UTF8 (1 << 9)
 .RE
 \f[]

--- a/src/cmark.h
+++ b/src/cmark.h
@@ -563,6 +563,10 @@ char *cmark_render_latex(cmark_node *root, int options, int width);
  * ### Options affecting parsing
  */
 
+/** Legacy option (no effect).
+ */
+#define CMARK_OPT_NORMALIZE (1 << 8)
+
 /** Validate UTF-8 in the input before parsing, replacing illegal
  * sequences with the replacement character U+FFFD.
  */


### PR DESCRIPTION
Reverts jgm/cmark#194 — amending just revert the option define removal.