### PR TITLE
Don't scan past an EOL

### DIFF
--- a/src/scanners.c
+++ b/src/scanners.c
@@ -12622,7 +12622,7 @@ bufsize_t _scan_html_block_end_1(const unsigned char *p) {
     unsigned char yych;
     unsigned int yyaccept = 0;
     static const unsigned char yybm[] = {
-        0,  64, 64, 64, 64, 64, 64,  64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+        0,  64, 64, 64, 64, 64, 64,  64, 64, 64, 0,  64, 64, 64, 64, 64, 64, 64,
         64, 64, 64, 64, 64, 64, 64,  64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
         64, 64, 64, 64, 64, 64, 64,  64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
         64, 64, 64, 64, 64, 64, 128, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
@@ -12639,24 +12639,24 @@ bufsize_t _scan_html_block_end_1(const unsigned char *p) {
         0,  0,  0,  0,
     };
     yych = *p;
-    if (yych <= 0xE0) {
-      if (yych <= '<') {
+    if (yych <= 0xDF) {
+      if (yych <= ';') {
         if (yych <= 0x00)
           goto yy766;
-        if (yych <= ';')
+        if (yych != '\n')
           goto yy768;
-        goto yy769;
       } else {
+        if (yych <= '<')
+          goto yy769;
         if (yych <= 0x7F)
           goto yy768;
-        if (yych <= 0xC1)
-          goto yy766;
-        if (yych <= 0xDF)
+        if (yych >= 0xC2)
           goto yy770;
-        goto yy771;
       }
     } else {
       if (yych <= 0xEF) {
+        if (yych <= 0xE0)
+          goto yy771;
         if (yych == 0xED)
           goto yy773;
         goto yy772;
@@ -12675,24 +12675,12 @@ bufsize_t _scan_html_block_end_1(const unsigned char *p) {
   yy768:
     yyaccept = 0;
     yych = *(marker = ++p);
-    if (yych <= 0x00)
-      goto yy767;
-    if (yych <= 0x7F)
-      goto yy781;
-    if (yych <= 0xC1)
-      goto yy767;
-    if (yych <= 0xF4)
-      goto yy781;
-    goto yy767;
-  yy769:
-    yyaccept = 0;
-    yych = *(marker = ++p);
-    if (yych <= '/') {
+    if (yych <= '\n') {
       if (yych <= 0x00)
         goto yy767;
-      if (yych <= '.')
+      if (yych <= '\t')
         goto yy781;
-      goto yy789;
+      goto yy767;
     } else {
       if (yych <= 0x7F)
         goto yy781;
@@ -12701,6 +12689,28 @@ bufsize_t _scan_html_block_end_1(const unsigned char *p) {
       if (yych <= 0xF4)
         goto yy781;
       goto yy767;
+    }
+  yy769:
+    yyaccept = 0;
+    yych = *(marker = ++p);
+    if (yych <= '.') {
+      if (yych <= 0x00)
+        goto yy767;
+      if (yych == '\n')
+        goto yy767;
+      goto yy781;
+    } else {
+      if (yych <= 0x7F) {
+        if (yych <= '/')
+          goto yy789;
+        goto yy781;
+      } else {
+        if (yych <= 0xC1)
+          goto yy767;
+        if (yych <= 0xF4)
+          goto yy781;
+        goto yy767;
+      }
     }
   yy770:
     yyaccept = 0;
@@ -12787,7 +12797,7 @@ bufsize_t _scan_html_block_end_1(const unsigned char *p) {
     }
     if (yych <= 0xEC) {
       if (yych <= 0xC1) {
-        if (yych <= 0x00)
+        if (yych <= '\n')
           goto yy778;
         if (yych >= '=')
           goto yy778;
@@ -12819,23 +12829,26 @@ bufsize_t _scan_html_block_end_1(const unsigned char *p) {
     if (yybm[0 + yych] & 128) {
       goto yy782;
     }
-    if (yych <= 0xE0) {
-      if (yych <= '/') {
+    if (yych <= 0xDF) {
+      if (yych <= '.') {
         if (yych <= 0x00)
           goto yy778;
-        if (yych <= '.')
-          goto yy780;
-        goto yy789;
+        if (yych == '\n')
+          goto yy778;
+        goto yy780;
       } else {
+        if (yych <= '/')
+          goto yy789;
         if (yych <= 0x7F)
           goto yy780;
         if (yych <= 0xC1)
           goto yy778;
-        if (yych <= 0xDF)
-          goto yy779;
+        goto yy779;
       }
     } else {
       if (yych <= 0xEF) {
+        if (yych <= 0xE0)
+          goto yy784;
         if (yych == 0xED)
           goto yy788;
         goto yy777;
@@ -12895,43 +12908,47 @@ bufsize_t _scan_html_block_end_1(const unsigned char *p) {
     if (yybm[0 + yych] & 128) {
       goto yy782;
     }
-    if (yych <= 0x7F) {
-      if (yych <= 'S') {
-        if (yych <= 'O') {
+    if (yych <= 's') {
+      if (yych <= 'P') {
+        if (yych <= '\t') {
           if (yych <= 0x00)
             goto yy778;
           goto yy780;
         } else {
-          if (yych <= 'P')
-            goto yy791;
-          if (yych <= 'R')
-            goto yy780;
-        }
-      } else {
-        if (yych <= 'p') {
-          if (yych <= 'o')
+          if (yych <= '\n')
+            goto yy778;
+          if (yych <= 'O')
             goto yy780;
           goto yy791;
+        }
+      } else {
+        if (yych <= 'o') {
+          if (yych != 'S')
+            goto yy780;
         } else {
-          if (yych != 's')
+          if (yych <= 'p')
+            goto yy791;
+          if (yych <= 'r')
             goto yy780;
         }
       }
     } else {
-      if (yych <= 0xED) {
-        if (yych <= 0xDF) {
-          if (yych <= 0xC1)
-            goto yy778;
-          goto yy779;
+      if (yych <= 0xEC) {
+        if (yych <= 0xC1) {
+          if (yych <= 0x7F)
+            goto yy780;
+          goto yy778;
         } else {
+          if (yych <= 0xDF)
+            goto yy779;
           if (yych <= 0xE0)
             goto yy784;
-          if (yych <= 0xEC)
-            goto yy777;
-          goto yy788;
+          goto yy777;
         }
       } else {
         if (yych <= 0xF0) {
+          if (yych <= 0xED)
+            goto yy788;
           if (yych <= 0xEF)
             goto yy777;
           goto yy785;
@@ -12949,45 +12966,49 @@ bufsize_t _scan_html_block_end_1(const unsigned char *p) {
     if (yybm[0 + yych] & 128) {
       goto yy782;
     }
-    if (yych <= 0x7F) {
-      if (yych <= 'T') {
-        if (yych <= 'B') {
+    if (yych <= 't') {
+      if (yych <= 'C') {
+        if (yych <= '\t') {
           if (yych <= 0x00)
             goto yy778;
           goto yy780;
         } else {
-          if (yych <= 'C')
+          if (yych <= '\n')
+            goto yy778;
+          if (yych <= 'B')
+            goto yy780;
+          goto yy796;
+        }
+      } else {
+        if (yych <= 'b') {
+          if (yych == 'T')
+            goto yy797;
+          goto yy780;
+        } else {
+          if (yych <= 'c')
             goto yy796;
-          if (yych <= 'S')
+          if (yych <= 's')
             goto yy780;
           goto yy797;
         }
-      } else {
-        if (yych <= 'c') {
-          if (yych <= 'b')
-            goto yy780;
-          goto yy796;
-        } else {
-          if (yych == 't')
-            goto yy797;
-          goto yy780;
-        }
       }
     } else {
-      if (yych <= 0xED) {
-        if (yych <= 0xDF) {
-          if (yych <= 0xC1)
-            goto yy778;
-          goto yy779;
+      if (yych <= 0xEC) {
+        if (yych <= 0xC1) {
+          if (yych <= 0x7F)
+            goto yy780;
+          goto yy778;
         } else {
+          if (yych <= 0xDF)
+            goto yy779;
           if (yych <= 0xE0)
             goto yy784;
-          if (yych <= 0xEC)
-            goto yy777;
-          goto yy788;
+          goto yy777;
         }
       } else {
         if (yych <= 0xF0) {
+          if (yych <= 0xED)
+            goto yy788;
           if (yych <= 0xEF)
             goto yy777;
           goto yy785;
@@ -13006,36 +13027,46 @@ bufsize_t _scan_html_block_end_1(const unsigned char *p) {
     if (yybm[0 + yych] & 128) {
       goto yy782;
     }
-    if (yych <= 0xDF) {
-      if (yych <= 'q') {
+    if (yych <= 0xC1) {
+      if (yych <= 'Q') {
         if (yych <= 0x00)
           goto yy778;
-        if (yych != 'R')
-          goto yy780;
-      } else {
-        if (yych <= 'r')
-          goto yy792;
-        if (yych <= 0x7F)
-          goto yy780;
-        if (yych <= 0xC1)
+        if (yych == '\n')
           goto yy778;
-        goto yy779;
+        goto yy780;
+      } else {
+        if (yych <= 'q') {
+          if (yych >= 'S')
+            goto yy780;
+        } else {
+          if (yych <= 'r')
+            goto yy792;
+          if (yych <= 0x7F)
+            goto yy780;
+          goto yy778;
+        }
       }
     } else {
-      if (yych <= 0xEF) {
+      if (yych <= 0xED) {
+        if (yych <= 0xDF)
+          goto yy779;
         if (yych <= 0xE0)
           goto yy784;
-        if (yych == 0xED)
-          goto yy788;
-        goto yy777;
+        if (yych <= 0xEC)
+          goto yy777;
+        goto yy788;
       } else {
-        if (yych <= 0xF0)
+        if (yych <= 0xF0) {
+          if (yych <= 0xEF)
+            goto yy777;
           goto yy785;
-        if (yych <= 0xF3)
-          goto yy786;
-        if (yych <= 0xF4)
-          goto yy787;
-        goto yy778;
+        } else {
+          if (yych <= 0xF3)
+            goto yy786;
+          if (yych <= 0xF4)
+            goto yy787;
+          goto yy778;
+        }
       }
     }
   yy792:
@@ -13044,15 +13075,64 @@ bufsize_t _scan_html_block_end_1(const unsigned char *p) {
     if (yybm[0 + yych] & 128) {
       goto yy782;
     }
-    if (yych <= 0xDF) {
-      if (yych <= 'd') {
+    if (yych <= 0xC1) {
+      if (yych <= 'D') {
         if (yych <= 0x00)
           goto yy778;
-        if (yych != 'E')
-          goto yy780;
+        if (yych == '\n')
+          goto yy778;
+        goto yy780;
       } else {
-        if (yych <= 'e')
-          goto yy793;
+        if (yych <= 'd') {
+          if (yych >= 'F')
+            goto yy780;
+        } else {
+          if (yych <= 'e')
+            goto yy793;
+          if (yych <= 0x7F)
+            goto yy780;
+          goto yy778;
+        }
+      }
+    } else {
+      if (yych <= 0xED) {
+        if (yych <= 0xDF)
+          goto yy779;
+        if (yych <= 0xE0)
+          goto yy784;
+        if (yych <= 0xEC)
+          goto yy777;
+        goto yy788;
+      } else {
+        if (yych <= 0xF0) {
+          if (yych <= 0xEF)
+            goto yy777;
+          goto yy785;
+        } else {
+          if (yych <= 0xF3)
+            goto yy786;
+          if (yych <= 0xF4)
+            goto yy787;
+          goto yy778;
+        }
+      }
+    }
+  yy793:
+    ++p;
+    yych = *p;
+    if (yybm[0 + yych] & 128) {
+      goto yy782;
+    }
+    if (yych <= 0xDF) {
+      if (yych <= '=') {
+        if (yych <= 0x00)
+          goto yy778;
+        if (yych == '\n')
+          goto yy778;
+        goto yy780;
+      } else {
+        if (yych <= '>')
+          goto yy794;
         if (yych <= 0x7F)
           goto yy780;
         if (yych <= 0xC1)
@@ -13076,42 +13156,7 @@ bufsize_t _scan_html_block_end_1(const unsigned char *p) {
         goto yy778;
       }
     }
-  yy793:
-    ++p;
-    yych = *p;
-    if (yybm[0 + yych] & 128) {
-      goto yy782;
-    }
-    if (yych <= 0xE0) {
-      if (yych <= '>') {
-        if (yych <= 0x00)
-          goto yy778;
-        if (yych <= '=')
-          goto yy780;
-      } else {
-        if (yych <= 0x7F)
-          goto yy780;
-        if (yych <= 0xC1)
-          goto yy778;
-        if (yych <= 0xDF)
-          goto yy779;
-        goto yy784;
-      }
-    } else {
-      if (yych <= 0xEF) {
-        if (yych == 0xED)
-          goto yy788;
-        goto yy777;
-      } else {
-        if (yych <= 0xF0)
-          goto yy785;
-        if (yych <= 0xF3)
-          goto yy786;
-        if (yych <= 0xF4)
-          goto yy787;
-        goto yy778;
-      }
-    }
+  yy794:
     yyaccept = 1;
     marker = ++p;
     yych = *p;
@@ -13120,7 +13165,7 @@ bufsize_t _scan_html_block_end_1(const unsigned char *p) {
     }
     if (yych <= 0xEC) {
       if (yych <= 0xC1) {
-        if (yych <= 0x00)
+        if (yych <= '\n')
           goto yy795;
         if (yych <= '<')
           goto yy782;
@@ -13152,37 +13197,47 @@ bufsize_t _scan_html_block_end_1(const unsigned char *p) {
     if (yybm[0 + yych] & 128) {
       goto yy782;
     }
-    if (yych <= 0xDF) {
-      if (yych <= 'q') {
+    if (yych <= 0xC1) {
+      if (yych <= 'Q') {
         if (yych <= 0x00)
           goto yy778;
-        if (yych == 'R')
-          goto yy800;
+        if (yych == '\n')
+          goto yy778;
         goto yy780;
       } else {
-        if (yych <= 'r')
-          goto yy800;
-        if (yych <= 0x7F)
+        if (yych <= 'q') {
+          if (yych <= 'R')
+            goto yy800;
           goto yy780;
-        if (yych <= 0xC1)
+        } else {
+          if (yych <= 'r')
+            goto yy800;
+          if (yych <= 0x7F)
+            goto yy780;
           goto yy778;
-        goto yy779;
+        }
       }
     } else {
-      if (yych <= 0xEF) {
+      if (yych <= 0xED) {
+        if (yych <= 0xDF)
+          goto yy779;
         if (yych <= 0xE0)
           goto yy784;
-        if (yych == 0xED)
-          goto yy788;
-        goto yy777;
+        if (yych <= 0xEC)
+          goto yy777;
+        goto yy788;
       } else {
-        if (yych <= 0xF0)
+        if (yych <= 0xF0) {
+          if (yych <= 0xEF)
+            goto yy777;
           goto yy785;
-        if (yych <= 0xF3)
-          goto yy786;
-        if (yych <= 0xF4)
-          goto yy787;
-        goto yy778;
+        } else {
+          if (yych <= 0xF3)
+            goto yy786;
+          if (yych <= 0xF4)
+            goto yy787;
+          goto yy778;
+        }
       }
     }
   yy797:
@@ -13191,36 +13246,46 @@ bufsize_t _scan_html_block_end_1(const unsigned char *p) {
     if (yybm[0 + yych] & 128) {
       goto yy782;
     }
-    if (yych <= 0xDF) {
-      if (yych <= 'x') {
+    if (yych <= 0xC1) {
+      if (yych <= 'X') {
         if (yych <= 0x00)
           goto yy778;
-        if (yych != 'Y')
-          goto yy780;
-      } else {
-        if (yych <= 'y')
-          goto yy798;
-        if (yych <= 0x7F)
-          goto yy780;
-        if (yych <= 0xC1)
+        if (yych == '\n')
           goto yy778;
-        goto yy779;
+        goto yy780;
+      } else {
+        if (yych <= 'x') {
+          if (yych >= 'Z')
+            goto yy780;
+        } else {
+          if (yych <= 'y')
+            goto yy798;
+          if (yych <= 0x7F)
+            goto yy780;
+          goto yy778;
+        }
       }
     } else {
-      if (yych <= 0xEF) {
+      if (yych <= 0xED) {
+        if (yych <= 0xDF)
+          goto yy779;
         if (yych <= 0xE0)
           goto yy784;
-        if (yych == 0xED)
-          goto yy788;
-        goto yy777;
+        if (yych <= 0xEC)
+          goto yy777;
+        goto yy788;
       } else {
-        if (yych <= 0xF0)
+        if (yych <= 0xF0) {
+          if (yych <= 0xEF)
+            goto yy777;
           goto yy785;
-        if (yych <= 0xF3)
-          goto yy786;
-        if (yych <= 0xF4)
-          goto yy787;
-        goto yy778;
+        } else {
+          if (yych <= 0xF3)
+            goto yy786;
+          if (yych <= 0xF4)
+            goto yy787;
+          goto yy778;
+        }
       }
     }
   yy798:
@@ -13229,36 +13294,46 @@ bufsize_t _scan_html_block_end_1(const unsigned char *p) {
     if (yybm[0 + yych] & 128) {
       goto yy782;
     }
-    if (yych <= 0xDF) {
-      if (yych <= 'k') {
+    if (yych <= 0xC1) {
+      if (yych <= 'K') {
         if (yych <= 0x00)
           goto yy778;
-        if (yych != 'L')
-          goto yy780;
-      } else {
-        if (yych <= 'l')
-          goto yy799;
-        if (yych <= 0x7F)
-          goto yy780;
-        if (yych <= 0xC1)
+        if (yych == '\n')
           goto yy778;
-        goto yy779;
+        goto yy780;
+      } else {
+        if (yych <= 'k') {
+          if (yych >= 'M')
+            goto yy780;
+        } else {
+          if (yych <= 'l')
+            goto yy799;
+          if (yych <= 0x7F)
+            goto yy780;
+          goto yy778;
+        }
       }
     } else {
-      if (yych <= 0xEF) {
+      if (yych <= 0xED) {
+        if (yych <= 0xDF)
+          goto yy779;
         if (yych <= 0xE0)
           goto yy784;
-        if (yych == 0xED)
-          goto yy788;
-        goto yy777;
+        if (yych <= 0xEC)
+          goto yy777;
+        goto yy788;
       } else {
-        if (yych <= 0xF0)
+        if (yych <= 0xF0) {
+          if (yych <= 0xEF)
+            goto yy777;
           goto yy785;
-        if (yych <= 0xF3)
-          goto yy786;
-        if (yych <= 0xF4)
-          goto yy787;
-        goto yy778;
+        } else {
+          if (yych <= 0xF3)
+            goto yy786;
+          if (yych <= 0xF4)
+            goto yy787;
+          goto yy778;
+        }
       }
     }
   yy799:
@@ -13267,37 +13342,47 @@ bufsize_t _scan_html_block_end_1(const unsigned char *p) {
     if (yybm[0 + yych] & 128) {
       goto yy782;
     }
-    if (yych <= 0xDF) {
-      if (yych <= 'd') {
+    if (yych <= 0xC1) {
+      if (yych <= 'D') {
         if (yych <= 0x00)
           goto yy778;
-        if (yych == 'E')
-          goto yy793;
+        if (yych == '\n')
+          goto yy778;
         goto yy780;
       } else {
-        if (yych <= 'e')
-          goto yy793;
-        if (yych <= 0x7F)
+        if (yych <= 'd') {
+          if (yych <= 'E')
+            goto yy793;
           goto yy780;
-        if (yych <= 0xC1)
+        } else {
+          if (yych <= 'e')
+            goto yy793;
+          if (yych <= 0x7F)
+            goto yy780;
           goto yy778;
-        goto yy779;
+        }
       }
     } else {
-      if (yych <= 0xEF) {
+      if (yych <= 0xED) {
+        if (yych <= 0xDF)
+          goto yy779;
         if (yych <= 0xE0)
           goto yy784;
-        if (yych == 0xED)
-          goto yy788;
-        goto yy777;
+        if (yych <= 0xEC)
+          goto yy777;
+        goto yy788;
       } else {
-        if (yych <= 0xF0)
+        if (yych <= 0xF0) {
+          if (yych <= 0xEF)
+            goto yy777;
           goto yy785;
-        if (yych <= 0xF3)
-          goto yy786;
-        if (yych <= 0xF4)
-          goto yy787;
-        goto yy778;
+        } else {
+          if (yych <= 0xF3)
+            goto yy786;
+          if (yych <= 0xF4)
+            goto yy787;
+          goto yy778;
+        }
       }
     }
   yy800:
@@ -13306,36 +13391,46 @@ bufsize_t _scan_html_block_end_1(const unsigned char *p) {
     if (yybm[0 + yych] & 128) {
       goto yy782;
     }
-    if (yych <= 0xDF) {
-      if (yych <= 'h') {
+    if (yych <= 0xC1) {
+      if (yych <= 'H') {
         if (yych <= 0x00)
           goto yy778;
-        if (yych != 'I')
-          goto yy780;
-      } else {
-        if (yych <= 'i')
-          goto yy801;
-        if (yych <= 0x7F)
-          goto yy780;
-        if (yych <= 0xC1)
+        if (yych == '\n')
           goto yy778;
-        goto yy779;
+        goto yy780;
+      } else {
+        if (yych <= 'h') {
+          if (yych >= 'J')
+            goto yy780;
+        } else {
+          if (yych <= 'i')
+            goto yy801;
+          if (yych <= 0x7F)
+            goto yy780;
+          goto yy778;
+        }
       }
     } else {
-      if (yych <= 0xEF) {
+      if (yych <= 0xED) {
+        if (yych <= 0xDF)
+          goto yy779;
         if (yych <= 0xE0)
           goto yy784;
-        if (yych == 0xED)
-          goto yy788;
-        goto yy777;
+        if (yych <= 0xEC)
+          goto yy777;
+        goto yy788;
       } else {
-        if (yych <= 0xF0)
+        if (yych <= 0xF0) {
+          if (yych <= 0xEF)
+            goto yy777;
           goto yy785;
-        if (yych <= 0xF3)
-          goto yy786;
-        if (yych <= 0xF4)
-          goto yy787;
-        goto yy778;
+        } else {
+          if (yych <= 0xF3)
+            goto yy786;
+          if (yych <= 0xF4)
+            goto yy787;
+          goto yy778;
+        }
       }
     }
   yy801:
@@ -13344,36 +13439,46 @@ bufsize_t _scan_html_block_end_1(const unsigned char *p) {
     if (yybm[0 + yych] & 128) {
       goto yy782;
     }
-    if (yych <= 0xDF) {
-      if (yych <= 'o') {
+    if (yych <= 0xC1) {
+      if (yych <= 'O') {
         if (yych <= 0x00)
           goto yy778;
-        if (yych != 'P')
-          goto yy780;
-      } else {
-        if (yych <= 'p')
-          goto yy802;
-        if (yych <= 0x7F)
-          goto yy780;
-        if (yych <= 0xC1)
+        if (yych == '\n')
           goto yy778;
-        goto yy779;
+        goto yy780;
+      } else {
+        if (yych <= 'o') {
+          if (yych >= 'Q')
+            goto yy780;
+        } else {
+          if (yych <= 'p')
+            goto yy802;
+          if (yych <= 0x7F)
+            goto yy780;
+          goto yy778;
+        }
       }
     } else {
-      if (yych <= 0xEF) {
+      if (yych <= 0xED) {
+        if (yych <= 0xDF)
+          goto yy779;
         if (yych <= 0xE0)
           goto yy784;
-        if (yych == 0xED)
-          goto yy788;
-        goto yy777;
+        if (yych <= 0xEC)
+          goto yy777;
+        goto yy788;
       } else {
-        if (yych <= 0xF0)
+        if (yych <= 0xF0) {
+          if (yych <= 0xEF)
+            goto yy777;
           goto yy785;
-        if (yych <= 0xF3)
-          goto yy786;
-        if (yych <= 0xF4)
-          goto yy787;
-        goto yy778;
+        } else {
+          if (yych <= 0xF3)
+            goto yy786;
+          if (yych <= 0xF4)
+            goto yy787;
+          goto yy778;
+        }
       }
     }
   yy802:
@@ -13382,37 +13487,47 @@ bufsize_t _scan_html_block_end_1(const unsigned char *p) {
     if (yybm[0 + yych] & 128) {
       goto yy782;
     }
-    if (yych <= 0xDF) {
-      if (yych <= 's') {
+    if (yych <= 0xC1) {
+      if (yych <= 'S') {
         if (yych <= 0x00)
           goto yy778;
-        if (yych == 'T')
-          goto yy793;
+        if (yych == '\n')
+          goto yy778;
         goto yy780;
       } else {
-        if (yych <= 't')
-          goto yy793;
-        if (yych <= 0x7F)
+        if (yych <= 's') {
+          if (yych <= 'T')
+            goto yy793;
           goto yy780;
-        if (yych <= 0xC1)
+        } else {
+          if (yych <= 't')
+            goto yy793;
+          if (yych <= 0x7F)
+            goto yy780;
           goto yy778;
-        goto yy779;
+        }
       }
     } else {
-      if (yych <= 0xEF) {
+      if (yych <= 0xED) {
+        if (yych <= 0xDF)
+          goto yy779;
         if (yych <= 0xE0)
           goto yy784;
-        if (yych == 0xED)
-          goto yy788;
-        goto yy777;
+        if (yych <= 0xEC)
+          goto yy777;
+        goto yy788;
       } else {
-        if (yych <= 0xF0)
+        if (yych <= 0xF0) {
+          if (yych <= 0xEF)
+            goto yy777;
           goto yy785;
-        if (yych <= 0xF3)
-          goto yy786;
-        if (yych <= 0xF4)
-          goto yy787;
-        goto yy778;
+        } else {
+          if (yych <= 0xF3)
+            goto yy786;
+          if (yych <= 0xF4)
+            goto yy787;
+          goto yy778;
+        }
       }
     }
   }
@@ -13427,7 +13542,7 @@ bufsize_t _scan_html_block_end_2(const unsigned char *p) {
     unsigned char yych;
     unsigned int yyaccept = 0;
     static const unsigned char yybm[] = {
-        0,  64, 64, 64, 64, 64, 64, 64, 64, 64,  64, 64, 64, 64, 64, 64, 64, 64,
+        0,  64, 64, 64, 64, 64, 64, 64, 64, 64,  0,  64, 64, 64, 64, 64, 64, 64,
         64, 64, 64, 64, 64, 64, 64, 64, 64, 64,  64, 64, 64, 64, 64, 64, 64, 64,
         64, 64, 64, 64, 64, 64, 64, 64, 64, 128, 64, 64, 64, 64, 64, 64, 64, 64,
         64, 64, 64, 64, 64, 64, 64, 64, 64, 64,  64, 64, 64, 64, 64, 64, 64, 64,
@@ -13444,24 +13559,24 @@ bufsize_t _scan_html_block_end_2(const unsigned char *p) {
         0,  0,  0,  0,
     };
     yych = *p;
-    if (yych <= 0xE0) {
-      if (yych <= '-') {
+    if (yych <= 0xDF) {
+      if (yych <= ',') {
         if (yych <= 0x00)
           goto yy805;
-        if (yych <= ',')
+        if (yych != '\n')
           goto yy807;
-        goto yy808;
       } else {
+        if (yych <= '-')
+          goto yy808;
         if (yych <= 0x7F)
           goto yy807;
-        if (yych <= 0xC1)
-          goto yy805;
-        if (yych <= 0xDF)
+        if (yych >= 0xC2)
           goto yy809;
-        goto yy810;
       }
     } else {
       if (yych <= 0xEF) {
+        if (yych <= 0xE0)
+          goto yy810;
         if (yych == 0xED)
           goto yy812;
         goto yy811;
@@ -13480,30 +13595,42 @@ bufsize_t _scan_html_block_end_2(const unsigned char *p) {
   yy807:
     yyaccept = 0;
     yych = *(marker = ++p);
-    if (yych <= 0x00)
+    if (yych <= '\n') {
+      if (yych <= 0x00)
+        goto yy806;
+      if (yych <= '\t')
+        goto yy820;
       goto yy806;
-    if (yych <= 0x7F)
-      goto yy820;
-    if (yych <= 0xC1)
+    } else {
+      if (yych <= 0x7F)
+        goto yy820;
+      if (yych <= 0xC1)
+        goto yy806;
+      if (yych <= 0xF4)
+        goto yy820;
       goto yy806;
-    if (yych <= 0xF4)
-      goto yy820;
-    goto yy806;
+    }
   yy808:
     yyaccept = 0;
     yych = *(marker = ++p);
     if (yybm[0 + yych] & 128) {
       goto yy827;
     }
-    if (yych <= 0x00)
+    if (yych <= '\n') {
+      if (yych <= 0x00)
+        goto yy806;
+      if (yych <= '\t')
+        goto yy820;
       goto yy806;
-    if (yych <= 0x7F)
-      goto yy820;
-    if (yych <= 0xC1)
+    } else {
+      if (yych <= 0x7F)
+        goto yy820;
+      if (yych <= 0xC1)
+        goto yy806;
+      if (yych <= 0xF4)
+        goto yy820;
       goto yy806;
-    if (yych <= 0xF4)
-      goto yy820;
-    goto yy806;
+    }
   yy809:
     yyaccept = 0;
     yych = *(marker = ++p);
@@ -13589,7 +13716,7 @@ bufsize_t _scan_html_block_end_2(const unsigned char *p) {
     }
     if (yych <= 0xEC) {
       if (yych <= 0xC1) {
-        if (yych <= 0x00)
+        if (yych <= '\n')
           goto yy817;
         if (yych >= '.')
           goto yy817;
@@ -13623,7 +13750,7 @@ bufsize_t _scan_html_block_end_2(const unsigned char *p) {
     }
     if (yych <= 0xEC) {
       if (yych <= 0xC1) {
-        if (yych <= 0x00)
+        if (yych <= '\n')
           goto yy817;
         if (yych <= '-')
           goto yy827;
@@ -13695,23 +13822,26 @@ bufsize_t _scan_html_block_end_2(const unsigned char *p) {
     if (yybm[0 + yych] & 128) {
       goto yy827;
     }
-    if (yych <= 0xE0) {
-      if (yych <= '>') {
+    if (yych <= 0xDF) {
+      if (yych <= '=') {
         if (yych <= 0x00)
           goto yy817;
-        if (yych <= '=')
-          goto yy819;
+        if (yych == '\n')
+          goto yy817;
+        goto yy819;
       } else {
+        if (yych <= '>')
+          goto yy829;
         if (yych <= 0x7F)
           goto yy819;
         if (yych <= 0xC1)
           goto yy817;
-        if (yych <= 0xDF)
-          goto yy818;
-        goto yy822;
+        goto yy818;
       }
     } else {
       if (yych <= 0xEF) {
+        if (yych <= 0xE0)
+          goto yy822;
         if (yych == 0xED)
           goto yy826;
         goto yy816;
@@ -13725,6 +13855,7 @@ bufsize_t _scan_html_block_end_2(const unsigned char *p) {
         goto yy817;
       }
     }
+  yy829:
     yyaccept = 1;
     marker = ++p;
     yych = *p;
@@ -13733,7 +13864,7 @@ bufsize_t _scan_html_block_end_2(const unsigned char *p) {
     }
     if (yych <= 0xEC) {
       if (yych <= 0xC1) {
-        if (yych <= 0x00)
+        if (yych <= '\n')
           goto yy830;
         if (yych <= '-')
           goto yy821;
@@ -13771,7 +13902,7 @@ bufsize_t _scan_html_block_end_3(const unsigned char *p) {
     unsigned char yych;
     unsigned int yyaccept = 0;
     static const unsigned char yybm[] = {
-        0,  64, 64, 64, 64, 64, 64, 64, 64, 64,  64, 64, 64, 64, 64, 64, 64, 64,
+        0,  64, 64, 64, 64, 64, 64, 64, 64, 64,  0,  64, 64, 64, 64, 64, 64, 64,
         64, 64, 64, 64, 64, 64, 64, 64, 64, 64,  64, 64, 64, 64, 64, 64, 64, 64,
         64, 64, 64, 64, 64, 64, 64, 64, 64, 64,  64, 64, 64, 64, 64, 64, 64, 64,
         64, 64, 64, 64, 64, 64, 64, 64, 64, 128, 64, 64, 64, 64, 64, 64, 64, 64,
@@ -13788,24 +13919,24 @@ bufsize_t _scan_html_block_end_3(const unsigned char *p) {
         0,  0,  0,  0,
     };
     yych = *p;
-    if (yych <= 0xE0) {
-      if (yych <= '?') {
+    if (yych <= 0xDF) {
+      if (yych <= '>') {
         if (yych <= 0x00)
           goto yy833;
-        if (yych <= '>')
+        if (yych != '\n')
           goto yy835;
-        goto yy836;
       } else {
+        if (yych <= '?')
+          goto yy836;
         if (yych <= 0x7F)
           goto yy835;
-        if (yych <= 0xC1)
-          goto yy833;
-        if (yych <= 0xDF)
+        if (yych >= 0xC2)
           goto yy837;
-        goto yy838;
       }
     } else {
       if (yych <= 0xEF) {
+        if (yych <= 0xE0)
+          goto yy838;
         if (yych == 0xED)
           goto yy840;
         goto yy839;
@@ -13824,24 +13955,12 @@ bufsize_t _scan_html_block_end_3(const unsigned char *p) {
   yy835:
     yyaccept = 0;
     yych = *(marker = ++p);
-    if (yych <= 0x00)
-      goto yy834;
-    if (yych <= 0x7F)
-      goto yy848;
-    if (yych <= 0xC1)
-      goto yy834;
-    if (yych <= 0xF4)
-      goto yy848;
-    goto yy834;
-  yy836:
-    yyaccept = 0;
-    yych = *(marker = ++p);
-    if (yych <= '>') {
+    if (yych <= '\n') {
       if (yych <= 0x00)
         goto yy834;
-      if (yych <= '=')
+      if (yych <= '\t')
         goto yy848;
-      goto yy856;
+      goto yy834;
     } else {
       if (yych <= 0x7F)
         goto yy848;
@@ -13850,6 +13969,28 @@ bufsize_t _scan_html_block_end_3(const unsigned char *p) {
       if (yych <= 0xF4)
         goto yy848;
       goto yy834;
+    }
+  yy836:
+    yyaccept = 0;
+    yych = *(marker = ++p);
+    if (yych <= '=') {
+      if (yych <= 0x00)
+        goto yy834;
+      if (yych == '\n')
+        goto yy834;
+      goto yy848;
+    } else {
+      if (yych <= 0x7F) {
+        if (yych <= '>')
+          goto yy856;
+        goto yy848;
+      } else {
+        if (yych <= 0xC1)
+          goto yy834;
+        if (yych <= 0xF4)
+          goto yy848;
+        goto yy834;
+      }
     }
   yy837:
     yyaccept = 0;
@@ -13936,7 +14077,7 @@ bufsize_t _scan_html_block_end_3(const unsigned char *p) {
     }
     if (yych <= 0xEC) {
       if (yych <= 0xC1) {
-        if (yych <= 0x00)
+        if (yych <= '\n')
           goto yy845;
         if (yych >= '@')
           goto yy845;
@@ -13968,23 +14109,26 @@ bufsize_t _scan_html_block_end_3(const unsigned char *p) {
     if (yybm[0 + yych] & 128) {
       goto yy849;
     }
-    if (yych <= 0xE0) {
-      if (yych <= '>') {
+    if (yych <= 0xDF) {
+      if (yych <= '=') {
         if (yych <= 0x00)
           goto yy845;
-        if (yych <= '=')
-          goto yy847;
-        goto yy856;
+        if (yych == '\n')
+          goto yy845;
+        goto yy847;
       } else {
+        if (yych <= '>')
+          goto yy856;
         if (yych <= 0x7F)
           goto yy847;
         if (yych <= 0xC1)
           goto yy845;
-        if (yych <= 0xDF)
-          goto yy846;
+        goto yy846;
       }
     } else {
       if (yych <= 0xEF) {
+        if (yych <= 0xE0)
+          goto yy851;
         if (yych == 0xED)
           goto yy855;
         goto yy844;
@@ -14047,7 +14191,7 @@ bufsize_t _scan_html_block_end_3(const unsigned char *p) {
     }
     if (yych <= 0xEC) {
       if (yych <= 0xC1) {
-        if (yych <= 0x00)
+        if (yych <= '\n')
           goto yy857;
         if (yych <= '?')
           goto yy849;
@@ -14085,7 +14229,7 @@ bufsize_t _scan_html_block_end_4(const unsigned char *p) {
     unsigned char yych;
     unsigned int yyaccept = 0;
     static const unsigned char yybm[] = {
-        0,  64, 64, 64, 64, 64, 64, 64, 64,  64, 64, 64, 64, 64, 64, 64, 64, 64,
+        0,  64, 64, 64, 64, 64, 64, 64, 64,  64, 0,  64, 64, 64, 64, 64, 64, 64,
         64, 64, 64, 64, 64, 64, 64, 64, 64,  64, 64, 64, 64, 64, 64, 64, 64, 64,
         64, 64, 64, 64, 64, 64, 64, 64, 64,  64, 64, 64, 64, 64, 64, 64, 64, 64,
         64, 64, 64, 64, 64, 64, 64, 64, 128, 64, 64, 64, 64, 64, 64, 64, 64, 64,
@@ -14102,24 +14246,24 @@ bufsize_t _scan_html_block_end_4(const unsigned char *p) {
         0,  0,  0,  0,
     };
     yych = *p;
-    if (yych <= 0xE0) {
-      if (yych <= '>') {
+    if (yych <= 0xDF) {
+      if (yych <= '=') {
         if (yych <= 0x00)
           goto yy860;
-        if (yych <= '=')
+        if (yych != '\n')
           goto yy862;
-        goto yy863;
       } else {
+        if (yych <= '>')
+          goto yy863;
         if (yych <= 0x7F)
           goto yy862;
-        if (yych <= 0xC1)
-          goto yy860;
-        if (yych <= 0xDF)
+        if (yych >= 0xC2)
           goto yy865;
-        goto yy866;
       }
     } else {
       if (yych <= 0xEF) {
+        if (yych <= 0xE0)
+          goto yy866;
         if (yych == 0xED)
           goto yy868;
         goto yy867;
@@ -14138,26 +14282,37 @@ bufsize_t _scan_html_block_end_4(const unsigned char *p) {
   yy862:
     yyaccept = 0;
     yych = *(marker = ++p);
-    if (yych <= 0x00)
+    if (yych <= '\n') {
+      if (yych <= 0x00)
+        goto yy861;
+      if (yych <= '\t')
+        goto yy876;
       goto yy861;
-    if (yych <= 0x7F)
-      goto yy876;
-    if (yych <= 0xC1)
+    } else {
+      if (yych <= 0x7F)
+        goto yy876;
+      if (yych <= 0xC1)
+        goto yy861;
+      if (yych <= 0xF4)
+        goto yy876;
       goto yy861;
-    if (yych <= 0xF4)
-      goto yy876;
-    goto yy861;
+    }
   yy863:
     yyaccept = 1;
     yych = *(marker = ++p);
-    if (yych <= 0x00)
-      goto yy864;
-    if (yych <= 0x7F)
-      goto yy876;
-    if (yych <= 0xC1)
-      goto yy864;
-    if (yych <= 0xF4)
-      goto yy876;
+    if (yych <= '\n') {
+      if (yych <= 0x00)
+        goto yy864;
+      if (yych <= '\t')
+        goto yy876;
+    } else {
+      if (yych <= 0x7F)
+        goto yy876;
+      if (yych <= 0xC1)
+        goto yy864;
+      if (yych <= 0xF4)
+        goto yy876;
+    }
   yy864 : { return (bufsize_t)(p - start); }
   yy865:
     yyaccept = 0;
@@ -14244,7 +14399,7 @@ bufsize_t _scan_html_block_end_4(const unsigned char *p) {
     }
     if (yych <= 0xEC) {
       if (yych <= 0xC1) {
-        if (yych <= 0x00)
+        if (yych <= '\n')
           goto yy873;
         if (yych >= '?')
           goto yy873;
@@ -14279,7 +14434,7 @@ bufsize_t _scan_html_block_end_4(const unsigned char *p) {
     }
     if (yych <= 0xEC) {
       if (yych <= 0xC1) {
-        if (yych <= 0x00)
+        if (yych <= '\n')
           goto yy864;
         if (yych <= '>')
           goto yy877;
@@ -14357,7 +14512,7 @@ bufsize_t _scan_html_block_end_5(const unsigned char *p) {
     unsigned char yych;
     unsigned int yyaccept = 0;
     static const unsigned char yybm[] = {
-        0,  64, 64, 64,  64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+        0,  64, 64, 64,  64, 64, 64, 64, 64, 64, 0,  64, 64, 64, 64, 64, 64, 64,
         64, 64, 64, 64,  64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
         64, 64, 64, 64,  64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
         64, 64, 64, 64,  64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
@@ -14374,24 +14529,24 @@ bufsize_t _scan_html_block_end_5(const unsigned char *p) {
         0,  0,  0,  0,
     };
     yych = *p;
-    if (yych <= 0xE0) {
-      if (yych <= ']') {
+    if (yych <= 0xDF) {
+      if (yych <= '\\') {
         if (yych <= 0x00)
           goto yy886;
-        if (yych <= '\\')
+        if (yych != '\n')
           goto yy888;
-        goto yy889;
       } else {
+        if (yych <= ']')
+          goto yy889;
         if (yych <= 0x7F)
           goto yy888;
-        if (yych <= 0xC1)
-          goto yy886;
-        if (yych <= 0xDF)
+        if (yych >= 0xC2)
           goto yy890;
-        goto yy891;
       }
     } else {
       if (yych <= 0xEF) {
+        if (yych <= 0xE0)
+          goto yy891;
         if (yych == 0xED)
           goto yy893;
         goto yy892;
@@ -14410,30 +14565,42 @@ bufsize_t _scan_html_block_end_5(const unsigned char *p) {
   yy888:
     yyaccept = 0;
     yych = *(marker = ++p);
-    if (yych <= 0x00)
+    if (yych <= '\n') {
+      if (yych <= 0x00)
+        goto yy887;
+      if (yych <= '\t')
+        goto yy901;
       goto yy887;
-    if (yych <= 0x7F)
-      goto yy901;
-    if (yych <= 0xC1)
+    } else {
+      if (yych <= 0x7F)
+        goto yy901;
+      if (yych <= 0xC1)
+        goto yy887;
+      if (yych <= 0xF4)
+        goto yy901;
       goto yy887;
-    if (yych <= 0xF4)
-      goto yy901;
-    goto yy887;
+    }
   yy889:
     yyaccept = 0;
     yych = *(marker = ++p);
     if (yybm[0 + yych] & 128) {
       goto yy908;
     }
-    if (yych <= 0x00)
+    if (yych <= '\n') {
+      if (yych <= 0x00)
+        goto yy887;
+      if (yych <= '\t')
+        goto yy901;
       goto yy887;
-    if (yych <= 0x7F)
-      goto yy901;
-    if (yych <= 0xC1)
+    } else {
+      if (yych <= 0x7F)
+        goto yy901;
+      if (yych <= 0xC1)
+        goto yy887;
+      if (yych <= 0xF4)
+        goto yy901;
       goto yy887;
-    if (yych <= 0xF4)
-      goto yy901;
-    goto yy887;
+    }
   yy890:
     yyaccept = 0;
     yych = *(marker = ++p);
@@ -14519,7 +14686,7 @@ bufsize_t _scan_html_block_end_5(const unsigned char *p) {
     }
     if (yych <= 0xEC) {
       if (yych <= 0xC1) {
-        if (yych <= 0x00)
+        if (yych <= '\n')
           goto yy898;
         if (yych >= '^')
           goto yy898;
@@ -14553,7 +14720,7 @@ bufsize_t _scan_html_block_end_5(const unsigned char *p) {
     }
     if (yych <= 0xEC) {
       if (yych <= 0xC1) {
-        if (yych <= 0x00)
+        if (yych <= '\n')
           goto yy898;
         if (yych <= ']')
           goto yy908;
@@ -14625,23 +14792,26 @@ bufsize_t _scan_html_block_end_5(const unsigned char *p) {
     if (yybm[0 + yych] & 128) {
       goto yy908;
     }
-    if (yych <= 0xE0) {
-      if (yych <= '>') {
+    if (yych <= 0xDF) {
+      if (yych <= '=') {
         if (yych <= 0x00)
           goto yy898;
-        if (yych <= '=')
-          goto yy900;
+        if (yych == '\n')
+          goto yy898;
+        goto yy900;
       } else {
+        if (yych <= '>')
+          goto yy910;
         if (yych <= 0x7F)
           goto yy900;
         if (yych <= 0xC1)
           goto yy898;
-        if (yych <= 0xDF)
-          goto yy899;
-        goto yy903;
+        goto yy899;
       }
     } else {
       if (yych <= 0xEF) {
+        if (yych <= 0xE0)
+          goto yy903;
         if (yych == 0xED)
           goto yy907;
         goto yy897;
@@ -14655,6 +14825,7 @@ bufsize_t _scan_html_block_end_5(const unsigned char *p) {
         goto yy898;
       }
     }
+  yy910:
     yyaccept = 1;
     marker = ++p;
     yych = *p;
@@ -14663,7 +14834,7 @@ bufsize_t _scan_html_block_end_5(const unsigned char *p) {
     }
     if (yych <= 0xEC) {
       if (yych <= 0xC1) {
-        if (yych <= 0x00)
+        if (yych <= '\n')
           goto yy911;
         if (yych <= ']')
           goto yy902;

--- a/src/scanners.c
+++ b/src/scanners.c
@@ -12622,7 +12622,7 @@ bufsize_t _scan_html_block_end_1(const unsigned char *p) {
     unsigned char yych;
     unsigned int yyaccept = 0;
     static const unsigned char yybm[] = {
-        64, 64, 64, 64, 64, 64, 64,  64, 64, 64, 0,  64, 64, 64, 64, 64, 64, 64,
+        0,  64, 64, 64, 64, 64, 64,  64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
         64, 64, 64, 64, 64, 64, 64,  64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
         64, 64, 64, 64, 64, 64, 64,  64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
         64, 64, 64, 64, 64, 64, 128, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
@@ -12639,23 +12639,24 @@ bufsize_t _scan_html_block_end_1(const unsigned char *p) {
         0,  0,  0,  0,
     };
     yych = *p;
-    if (yych <= 0xDF) {
-      if (yych <= ';') {
-        if (yych == '\n')
-          goto yy768;
-      } else {
-        if (yych <= '<')
-          goto yy769;
-        if (yych <= 0x7F)
+    if (yych <= 0xE0) {
+      if (yych <= '<') {
+        if (yych <= 0x00)
           goto yy766;
-        if (yych <= 0xC1)
+        if (yych <= ';')
           goto yy768;
-        goto yy770;
+        goto yy769;
+      } else {
+        if (yych <= 0x7F)
+          goto yy768;
+        if (yych <= 0xC1)
+          goto yy766;
+        if (yych <= 0xDF)
+          goto yy770;
+        goto yy771;
       }
     } else {
       if (yych <= 0xEF) {
-        if (yych <= 0xE0)
-          goto yy771;
         if (yych == 0xED)
           goto yy773;
         goto yy772;
@@ -12666,30 +12667,28 @@ bufsize_t _scan_html_block_end_1(const unsigned char *p) {
           goto yy775;
         if (yych <= 0xF4)
           goto yy776;
-        goto yy768;
       }
     }
   yy766:
-    yyaccept = 0;
-    yych = *(marker = ++p);
-    if (yych <= 0x7F) {
-      if (yych != '\n')
-        goto yy781;
-    } else {
-      if (yych <= 0xC1)
-        goto yy767;
-      if (yych <= 0xF4)
-        goto yy781;
-    }
+    ++p;
   yy767 : { return 0; }
   yy768:
-    yych = *++p;
+    yyaccept = 0;
+    yych = *(marker = ++p);
+    if (yych <= 0x00)
+      goto yy767;
+    if (yych <= 0x7F)
+      goto yy781;
+    if (yych <= 0xC1)
+      goto yy767;
+    if (yych <= 0xF4)
+      goto yy781;
     goto yy767;
   yy769:
     yyaccept = 0;
     yych = *(marker = ++p);
     if (yych <= '/') {
-      if (yych == '\n')
+      if (yych <= 0x00)
         goto yy767;
       if (yych <= '.')
         goto yy781;
@@ -12788,7 +12787,7 @@ bufsize_t _scan_html_block_end_1(const unsigned char *p) {
     }
     if (yych <= 0xEC) {
       if (yych <= 0xC1) {
-        if (yych <= '\n')
+        if (yych <= 0x00)
           goto yy778;
         if (yych >= '=')
           goto yy778;
@@ -12820,24 +12819,23 @@ bufsize_t _scan_html_block_end_1(const unsigned char *p) {
     if (yybm[0 + yych] & 128) {
       goto yy782;
     }
-    if (yych <= 0xDF) {
-      if (yych <= '.') {
-        if (yych == '\n')
+    if (yych <= 0xE0) {
+      if (yych <= '/') {
+        if (yych <= 0x00)
           goto yy778;
-        goto yy780;
+        if (yych <= '.')
+          goto yy780;
+        goto yy789;
       } else {
-        if (yych <= '/')
-          goto yy789;
         if (yych <= 0x7F)
           goto yy780;
         if (yych <= 0xC1)
           goto yy778;
-        goto yy779;
+        if (yych <= 0xDF)
+          goto yy779;
       }
     } else {
       if (yych <= 0xEF) {
-        if (yych <= 0xE0)
-          goto yy784;
         if (yych == 0xED)
           goto yy788;
         goto yy777;
@@ -12897,45 +12895,43 @@ bufsize_t _scan_html_block_end_1(const unsigned char *p) {
     if (yybm[0 + yych] & 128) {
       goto yy782;
     }
-    if (yych <= 's') {
-      if (yych <= 'R') {
-        if (yych <= '\n') {
-          if (yych <= '\t')
-            goto yy780;
-          goto yy778;
-        } else {
-          if (yych == 'P')
-            goto yy791;
+    if (yych <= 0x7F) {
+      if (yych <= 'S') {
+        if (yych <= 'O') {
+          if (yych <= 0x00)
+            goto yy778;
           goto yy780;
+        } else {
+          if (yych <= 'P')
+            goto yy791;
+          if (yych <= 'R')
+            goto yy780;
         }
       } else {
-        if (yych <= 'o') {
-          if (yych >= 'T')
+        if (yych <= 'p') {
+          if (yych <= 'o')
             goto yy780;
+          goto yy791;
         } else {
-          if (yych <= 'p')
-            goto yy791;
-          if (yych <= 'r')
+          if (yych != 's')
             goto yy780;
         }
       }
     } else {
-      if (yych <= 0xEC) {
-        if (yych <= 0xC1) {
-          if (yych <= 0x7F)
-            goto yy780;
-          goto yy778;
+      if (yych <= 0xED) {
+        if (yych <= 0xDF) {
+          if (yych <= 0xC1)
+            goto yy778;
+          goto yy779;
         } else {
-          if (yych <= 0xDF)
-            goto yy779;
           if (yych <= 0xE0)
             goto yy784;
-          goto yy777;
+          if (yych <= 0xEC)
+            goto yy777;
+          goto yy788;
         }
       } else {
         if (yych <= 0xF0) {
-          if (yych <= 0xED)
-            goto yy788;
           if (yych <= 0xEF)
             goto yy777;
           goto yy785;
@@ -12953,47 +12949,45 @@ bufsize_t _scan_html_block_end_1(const unsigned char *p) {
     if (yybm[0 + yych] & 128) {
       goto yy782;
     }
-    if (yych <= 't') {
-      if (yych <= 'S') {
-        if (yych <= '\n') {
-          if (yych <= '\t')
-            goto yy780;
-          goto yy778;
-        } else {
-          if (yych == 'C')
-            goto yy796;
-          goto yy780;
-        }
-      } else {
-        if (yych <= 'b') {
-          if (yych <= 'T')
-            goto yy797;
+    if (yych <= 0x7F) {
+      if (yych <= 'T') {
+        if (yych <= 'B') {
+          if (yych <= 0x00)
+            goto yy778;
           goto yy780;
         } else {
-          if (yych <= 'c')
+          if (yych <= 'C')
             goto yy796;
-          if (yych <= 's')
+          if (yych <= 'S')
             goto yy780;
           goto yy797;
         }
+      } else {
+        if (yych <= 'c') {
+          if (yych <= 'b')
+            goto yy780;
+          goto yy796;
+        } else {
+          if (yych == 't')
+            goto yy797;
+          goto yy780;
+        }
       }
     } else {
-      if (yych <= 0xEC) {
-        if (yych <= 0xC1) {
-          if (yych <= 0x7F)
-            goto yy780;
-          goto yy778;
+      if (yych <= 0xED) {
+        if (yych <= 0xDF) {
+          if (yych <= 0xC1)
+            goto yy778;
+          goto yy779;
         } else {
-          if (yych <= 0xDF)
-            goto yy779;
           if (yych <= 0xE0)
             goto yy784;
-          goto yy777;
+          if (yych <= 0xEC)
+            goto yy777;
+          goto yy788;
         }
       } else {
         if (yych <= 0xF0) {
-          if (yych <= 0xED)
-            goto yy788;
           if (yych <= 0xEF)
             goto yy777;
           goto yy785;
@@ -13012,98 +13006,15 @@ bufsize_t _scan_html_block_end_1(const unsigned char *p) {
     if (yybm[0 + yych] & 128) {
       goto yy782;
     }
-    if (yych <= 0xC1) {
-      if (yych <= 'R') {
-        if (yych == '\n')
-          goto yy778;
-        if (yych <= 'Q')
-          goto yy780;
-      } else {
-        if (yych == 'r')
-          goto yy792;
-        if (yych <= 0x7F)
-          goto yy780;
-        goto yy778;
-      }
-    } else {
-      if (yych <= 0xED) {
-        if (yych <= 0xDF)
-          goto yy779;
-        if (yych <= 0xE0)
-          goto yy784;
-        if (yych <= 0xEC)
-          goto yy777;
-        goto yy788;
-      } else {
-        if (yych <= 0xF0) {
-          if (yych <= 0xEF)
-            goto yy777;
-          goto yy785;
-        } else {
-          if (yych <= 0xF3)
-            goto yy786;
-          if (yych <= 0xF4)
-            goto yy787;
-          goto yy778;
-        }
-      }
-    }
-  yy792:
-    ++p;
-    yych = *p;
-    if (yybm[0 + yych] & 128) {
-      goto yy782;
-    }
-    if (yych <= 0xC1) {
-      if (yych <= 'E') {
-        if (yych == '\n')
-          goto yy778;
-        if (yych <= 'D')
-          goto yy780;
-      } else {
-        if (yych == 'e')
-          goto yy793;
-        if (yych <= 0x7F)
-          goto yy780;
-        goto yy778;
-      }
-    } else {
-      if (yych <= 0xED) {
-        if (yych <= 0xDF)
-          goto yy779;
-        if (yych <= 0xE0)
-          goto yy784;
-        if (yych <= 0xEC)
-          goto yy777;
-        goto yy788;
-      } else {
-        if (yych <= 0xF0) {
-          if (yych <= 0xEF)
-            goto yy777;
-          goto yy785;
-        } else {
-          if (yych <= 0xF3)
-            goto yy786;
-          if (yych <= 0xF4)
-            goto yy787;
-          goto yy778;
-        }
-      }
-    }
-  yy793:
-    ++p;
-    yych = *p;
-    if (yybm[0 + yych] & 128) {
-      goto yy782;
-    }
     if (yych <= 0xDF) {
-      if (yych <= '=') {
-        if (yych == '\n')
+      if (yych <= 'q') {
+        if (yych <= 0x00)
           goto yy778;
-        goto yy780;
+        if (yych != 'R')
+          goto yy780;
       } else {
-        if (yych <= '>')
-          goto yy794;
+        if (yych <= 'r')
+          goto yy792;
         if (yych <= 0x7F)
           goto yy780;
         if (yych <= 0xC1)
@@ -13127,7 +13038,80 @@ bufsize_t _scan_html_block_end_1(const unsigned char *p) {
         goto yy778;
       }
     }
-  yy794:
+  yy792:
+    ++p;
+    yych = *p;
+    if (yybm[0 + yych] & 128) {
+      goto yy782;
+    }
+    if (yych <= 0xDF) {
+      if (yych <= 'd') {
+        if (yych <= 0x00)
+          goto yy778;
+        if (yych != 'E')
+          goto yy780;
+      } else {
+        if (yych <= 'e')
+          goto yy793;
+        if (yych <= 0x7F)
+          goto yy780;
+        if (yych <= 0xC1)
+          goto yy778;
+        goto yy779;
+      }
+    } else {
+      if (yych <= 0xEF) {
+        if (yych <= 0xE0)
+          goto yy784;
+        if (yych == 0xED)
+          goto yy788;
+        goto yy777;
+      } else {
+        if (yych <= 0xF0)
+          goto yy785;
+        if (yych <= 0xF3)
+          goto yy786;
+        if (yych <= 0xF4)
+          goto yy787;
+        goto yy778;
+      }
+    }
+  yy793:
+    ++p;
+    yych = *p;
+    if (yybm[0 + yych] & 128) {
+      goto yy782;
+    }
+    if (yych <= 0xE0) {
+      if (yych <= '>') {
+        if (yych <= 0x00)
+          goto yy778;
+        if (yych <= '=')
+          goto yy780;
+      } else {
+        if (yych <= 0x7F)
+          goto yy780;
+        if (yych <= 0xC1)
+          goto yy778;
+        if (yych <= 0xDF)
+          goto yy779;
+        goto yy784;
+      }
+    } else {
+      if (yych <= 0xEF) {
+        if (yych == 0xED)
+          goto yy788;
+        goto yy777;
+      } else {
+        if (yych <= 0xF0)
+          goto yy785;
+        if (yych <= 0xF3)
+          goto yy786;
+        if (yych <= 0xF4)
+          goto yy787;
+        goto yy778;
+      }
+    }
     yyaccept = 1;
     marker = ++p;
     yych = *p;
@@ -13136,7 +13120,7 @@ bufsize_t _scan_html_block_end_1(const unsigned char *p) {
     }
     if (yych <= 0xEC) {
       if (yych <= 0xC1) {
-        if (yych <= '\n')
+        if (yych <= 0x00)
           goto yy795;
         if (yych <= '<')
           goto yy782;
@@ -13168,41 +13152,37 @@ bufsize_t _scan_html_block_end_1(const unsigned char *p) {
     if (yybm[0 + yych] & 128) {
       goto yy782;
     }
-    if (yych <= 0xC1) {
-      if (yych <= 'R') {
-        if (yych == '\n')
+    if (yych <= 0xDF) {
+      if (yych <= 'q') {
+        if (yych <= 0x00)
           goto yy778;
-        if (yych <= 'Q')
-          goto yy780;
-        goto yy800;
+        if (yych == 'R')
+          goto yy800;
+        goto yy780;
       } else {
-        if (yych == 'r')
+        if (yych <= 'r')
           goto yy800;
         if (yych <= 0x7F)
           goto yy780;
-        goto yy778;
+        if (yych <= 0xC1)
+          goto yy778;
+        goto yy779;
       }
     } else {
-      if (yych <= 0xED) {
-        if (yych <= 0xDF)
-          goto yy779;
+      if (yych <= 0xEF) {
         if (yych <= 0xE0)
           goto yy784;
-        if (yych <= 0xEC)
-          goto yy777;
-        goto yy788;
+        if (yych == 0xED)
+          goto yy788;
+        goto yy777;
       } else {
-        if (yych <= 0xF0) {
-          if (yych <= 0xEF)
-            goto yy777;
+        if (yych <= 0xF0)
           goto yy785;
-        } else {
-          if (yych <= 0xF3)
-            goto yy786;
-          if (yych <= 0xF4)
-            goto yy787;
-          goto yy778;
-        }
+        if (yych <= 0xF3)
+          goto yy786;
+        if (yych <= 0xF4)
+          goto yy787;
+        goto yy778;
       }
     }
   yy797:
@@ -13211,40 +13191,36 @@ bufsize_t _scan_html_block_end_1(const unsigned char *p) {
     if (yybm[0 + yych] & 128) {
       goto yy782;
     }
-    if (yych <= 0xC1) {
-      if (yych <= 'Y') {
-        if (yych == '\n')
+    if (yych <= 0xDF) {
+      if (yych <= 'x') {
+        if (yych <= 0x00)
           goto yy778;
-        if (yych <= 'X')
+        if (yych != 'Y')
           goto yy780;
       } else {
-        if (yych == 'y')
+        if (yych <= 'y')
           goto yy798;
         if (yych <= 0x7F)
           goto yy780;
-        goto yy778;
+        if (yych <= 0xC1)
+          goto yy778;
+        goto yy779;
       }
     } else {
-      if (yych <= 0xED) {
-        if (yych <= 0xDF)
-          goto yy779;
+      if (yych <= 0xEF) {
         if (yych <= 0xE0)
           goto yy784;
-        if (yych <= 0xEC)
-          goto yy777;
-        goto yy788;
+        if (yych == 0xED)
+          goto yy788;
+        goto yy777;
       } else {
-        if (yych <= 0xF0) {
-          if (yych <= 0xEF)
-            goto yy777;
+        if (yych <= 0xF0)
           goto yy785;
-        } else {
-          if (yych <= 0xF3)
-            goto yy786;
-          if (yych <= 0xF4)
-            goto yy787;
-          goto yy778;
-        }
+        if (yych <= 0xF3)
+          goto yy786;
+        if (yych <= 0xF4)
+          goto yy787;
+        goto yy778;
       }
     }
   yy798:
@@ -13253,40 +13229,36 @@ bufsize_t _scan_html_block_end_1(const unsigned char *p) {
     if (yybm[0 + yych] & 128) {
       goto yy782;
     }
-    if (yych <= 0xC1) {
-      if (yych <= 'L') {
-        if (yych == '\n')
+    if (yych <= 0xDF) {
+      if (yych <= 'k') {
+        if (yych <= 0x00)
           goto yy778;
-        if (yych <= 'K')
+        if (yych != 'L')
           goto yy780;
       } else {
-        if (yych == 'l')
+        if (yych <= 'l')
           goto yy799;
         if (yych <= 0x7F)
           goto yy780;
-        goto yy778;
+        if (yych <= 0xC1)
+          goto yy778;
+        goto yy779;
       }
     } else {
-      if (yych <= 0xED) {
-        if (yych <= 0xDF)
-          goto yy779;
+      if (yych <= 0xEF) {
         if (yych <= 0xE0)
           goto yy784;
-        if (yych <= 0xEC)
-          goto yy777;
-        goto yy788;
+        if (yych == 0xED)
+          goto yy788;
+        goto yy777;
       } else {
-        if (yych <= 0xF0) {
-          if (yych <= 0xEF)
-            goto yy777;
+        if (yych <= 0xF0)
           goto yy785;
-        } else {
-          if (yych <= 0xF3)
-            goto yy786;
-          if (yych <= 0xF4)
-            goto yy787;
-          goto yy778;
-        }
+        if (yych <= 0xF3)
+          goto yy786;
+        if (yych <= 0xF4)
+          goto yy787;
+        goto yy778;
       }
     }
   yy799:
@@ -13295,41 +13267,37 @@ bufsize_t _scan_html_block_end_1(const unsigned char *p) {
     if (yybm[0 + yych] & 128) {
       goto yy782;
     }
-    if (yych <= 0xC1) {
-      if (yych <= 'E') {
-        if (yych == '\n')
+    if (yych <= 0xDF) {
+      if (yych <= 'd') {
+        if (yych <= 0x00)
           goto yy778;
-        if (yych <= 'D')
-          goto yy780;
-        goto yy793;
+        if (yych == 'E')
+          goto yy793;
+        goto yy780;
       } else {
-        if (yych == 'e')
+        if (yych <= 'e')
           goto yy793;
         if (yych <= 0x7F)
           goto yy780;
-        goto yy778;
+        if (yych <= 0xC1)
+          goto yy778;
+        goto yy779;
       }
     } else {
-      if (yych <= 0xED) {
-        if (yych <= 0xDF)
-          goto yy779;
+      if (yych <= 0xEF) {
         if (yych <= 0xE0)
           goto yy784;
-        if (yych <= 0xEC)
-          goto yy777;
-        goto yy788;
+        if (yych == 0xED)
+          goto yy788;
+        goto yy777;
       } else {
-        if (yych <= 0xF0) {
-          if (yych <= 0xEF)
-            goto yy777;
+        if (yych <= 0xF0)
           goto yy785;
-        } else {
-          if (yych <= 0xF3)
-            goto yy786;
-          if (yych <= 0xF4)
-            goto yy787;
-          goto yy778;
-        }
+        if (yych <= 0xF3)
+          goto yy786;
+        if (yych <= 0xF4)
+          goto yy787;
+        goto yy778;
       }
     }
   yy800:
@@ -13338,40 +13306,36 @@ bufsize_t _scan_html_block_end_1(const unsigned char *p) {
     if (yybm[0 + yych] & 128) {
       goto yy782;
     }
-    if (yych <= 0xC1) {
-      if (yych <= 'I') {
-        if (yych == '\n')
+    if (yych <= 0xDF) {
+      if (yych <= 'h') {
+        if (yych <= 0x00)
           goto yy778;
-        if (yych <= 'H')
+        if (yych != 'I')
           goto yy780;
       } else {
-        if (yych == 'i')
+        if (yych <= 'i')
           goto yy801;
         if (yych <= 0x7F)
           goto yy780;
-        goto yy778;
+        if (yych <= 0xC1)
+          goto yy778;
+        goto yy779;
       }
     } else {
-      if (yych <= 0xED) {
-        if (yych <= 0xDF)
-          goto yy779;
+      if (yych <= 0xEF) {
         if (yych <= 0xE0)
           goto yy784;
-        if (yych <= 0xEC)
-          goto yy777;
-        goto yy788;
+        if (yych == 0xED)
+          goto yy788;
+        goto yy777;
       } else {
-        if (yych <= 0xF0) {
-          if (yych <= 0xEF)
-            goto yy777;
+        if (yych <= 0xF0)
           goto yy785;
-        } else {
-          if (yych <= 0xF3)
-            goto yy786;
-          if (yych <= 0xF4)
-            goto yy787;
-          goto yy778;
-        }
+        if (yych <= 0xF3)
+          goto yy786;
+        if (yych <= 0xF4)
+          goto yy787;
+        goto yy778;
       }
     }
   yy801:
@@ -13380,40 +13344,36 @@ bufsize_t _scan_html_block_end_1(const unsigned char *p) {
     if (yybm[0 + yych] & 128) {
       goto yy782;
     }
-    if (yych <= 0xC1) {
-      if (yych <= 'P') {
-        if (yych == '\n')
+    if (yych <= 0xDF) {
+      if (yych <= 'o') {
+        if (yych <= 0x00)
           goto yy778;
-        if (yych <= 'O')
+        if (yych != 'P')
           goto yy780;
       } else {
-        if (yych == 'p')
+        if (yych <= 'p')
           goto yy802;
         if (yych <= 0x7F)
           goto yy780;
-        goto yy778;
+        if (yych <= 0xC1)
+          goto yy778;
+        goto yy779;
       }
     } else {
-      if (yych <= 0xED) {
-        if (yych <= 0xDF)
-          goto yy779;
+      if (yych <= 0xEF) {
         if (yych <= 0xE0)
           goto yy784;
-        if (yych <= 0xEC)
-          goto yy777;
-        goto yy788;
+        if (yych == 0xED)
+          goto yy788;
+        goto yy777;
       } else {
-        if (yych <= 0xF0) {
-          if (yych <= 0xEF)
-            goto yy777;
+        if (yych <= 0xF0)
           goto yy785;
-        } else {
-          if (yych <= 0xF3)
-            goto yy786;
-          if (yych <= 0xF4)
-            goto yy787;
-          goto yy778;
-        }
+        if (yych <= 0xF3)
+          goto yy786;
+        if (yych <= 0xF4)
+          goto yy787;
+        goto yy778;
       }
     }
   yy802:
@@ -13422,41 +13382,37 @@ bufsize_t _scan_html_block_end_1(const unsigned char *p) {
     if (yybm[0 + yych] & 128) {
       goto yy782;
     }
-    if (yych <= 0xC1) {
-      if (yych <= 'T') {
-        if (yych == '\n')
+    if (yych <= 0xDF) {
+      if (yych <= 's') {
+        if (yych <= 0x00)
           goto yy778;
-        if (yych <= 'S')
-          goto yy780;
-        goto yy793;
+        if (yych == 'T')
+          goto yy793;
+        goto yy780;
       } else {
-        if (yych == 't')
+        if (yych <= 't')
           goto yy793;
         if (yych <= 0x7F)
           goto yy780;
-        goto yy778;
+        if (yych <= 0xC1)
+          goto yy778;
+        goto yy779;
       }
     } else {
-      if (yych <= 0xED) {
-        if (yych <= 0xDF)
-          goto yy779;
+      if (yych <= 0xEF) {
         if (yych <= 0xE0)
           goto yy784;
-        if (yych <= 0xEC)
-          goto yy777;
-        goto yy788;
+        if (yych == 0xED)
+          goto yy788;
+        goto yy777;
       } else {
-        if (yych <= 0xF0) {
-          if (yych <= 0xEF)
-            goto yy777;
+        if (yych <= 0xF0)
           goto yy785;
-        } else {
-          if (yych <= 0xF3)
-            goto yy786;
-          if (yych <= 0xF4)
-            goto yy787;
-          goto yy778;
-        }
+        if (yych <= 0xF3)
+          goto yy786;
+        if (yych <= 0xF4)
+          goto yy787;
+        goto yy778;
       }
     }
   }
@@ -13471,7 +13427,7 @@ bufsize_t _scan_html_block_end_2(const unsigned char *p) {
     unsigned char yych;
     unsigned int yyaccept = 0;
     static const unsigned char yybm[] = {
-        64, 64, 64, 64, 64, 64, 64, 64, 64, 64,  0,  64, 64, 64, 64, 64, 64, 64,
+        0,  64, 64, 64, 64, 64, 64, 64, 64, 64,  64, 64, 64, 64, 64, 64, 64, 64,
         64, 64, 64, 64, 64, 64, 64, 64, 64, 64,  64, 64, 64, 64, 64, 64, 64, 64,
         64, 64, 64, 64, 64, 64, 64, 64, 64, 128, 64, 64, 64, 64, 64, 64, 64, 64,
         64, 64, 64, 64, 64, 64, 64, 64, 64, 64,  64, 64, 64, 64, 64, 64, 64, 64,
@@ -13488,23 +13444,24 @@ bufsize_t _scan_html_block_end_2(const unsigned char *p) {
         0,  0,  0,  0,
     };
     yych = *p;
-    if (yych <= 0xDF) {
-      if (yych <= ',') {
-        if (yych == '\n')
-          goto yy807;
-      } else {
-        if (yych <= '-')
-          goto yy808;
-        if (yych <= 0x7F)
+    if (yych <= 0xE0) {
+      if (yych <= '-') {
+        if (yych <= 0x00)
           goto yy805;
-        if (yych <= 0xC1)
+        if (yych <= ',')
           goto yy807;
-        goto yy809;
+        goto yy808;
+      } else {
+        if (yych <= 0x7F)
+          goto yy807;
+        if (yych <= 0xC1)
+          goto yy805;
+        if (yych <= 0xDF)
+          goto yy809;
+        goto yy810;
       }
     } else {
       if (yych <= 0xEF) {
-        if (yych <= 0xE0)
-          goto yy810;
         if (yych == 0xED)
           goto yy812;
         goto yy811;
@@ -13515,24 +13472,22 @@ bufsize_t _scan_html_block_end_2(const unsigned char *p) {
           goto yy814;
         if (yych <= 0xF4)
           goto yy815;
-        goto yy807;
       }
     }
   yy805:
-    yyaccept = 0;
-    yych = *(marker = ++p);
-    if (yych <= 0x7F) {
-      if (yych != '\n')
-        goto yy820;
-    } else {
-      if (yych <= 0xC1)
-        goto yy806;
-      if (yych <= 0xF4)
-        goto yy820;
-    }
+    ++p;
   yy806 : { return 0; }
   yy807:
-    yych = *++p;
+    yyaccept = 0;
+    yych = *(marker = ++p);
+    if (yych <= 0x00)
+      goto yy806;
+    if (yych <= 0x7F)
+      goto yy820;
+    if (yych <= 0xC1)
+      goto yy806;
+    if (yych <= 0xF4)
+      goto yy820;
     goto yy806;
   yy808:
     yyaccept = 0;
@@ -13540,17 +13495,15 @@ bufsize_t _scan_html_block_end_2(const unsigned char *p) {
     if (yybm[0 + yych] & 128) {
       goto yy827;
     }
-    if (yych <= 0x7F) {
-      if (yych == '\n')
-        goto yy806;
-      goto yy820;
-    } else {
-      if (yych <= 0xC1)
-        goto yy806;
-      if (yych <= 0xF4)
-        goto yy820;
+    if (yych <= 0x00)
       goto yy806;
-    }
+    if (yych <= 0x7F)
+      goto yy820;
+    if (yych <= 0xC1)
+      goto yy806;
+    if (yych <= 0xF4)
+      goto yy820;
+    goto yy806;
   yy809:
     yyaccept = 0;
     yych = *(marker = ++p);
@@ -13636,7 +13589,7 @@ bufsize_t _scan_html_block_end_2(const unsigned char *p) {
     }
     if (yych <= 0xEC) {
       if (yych <= 0xC1) {
-        if (yych <= '\n')
+        if (yych <= 0x00)
           goto yy817;
         if (yych >= '.')
           goto yy817;
@@ -13670,7 +13623,7 @@ bufsize_t _scan_html_block_end_2(const unsigned char *p) {
     }
     if (yych <= 0xEC) {
       if (yych <= 0xC1) {
-        if (yych <= '\n')
+        if (yych <= 0x00)
           goto yy817;
         if (yych <= '-')
           goto yy827;
@@ -13742,24 +13695,23 @@ bufsize_t _scan_html_block_end_2(const unsigned char *p) {
     if (yybm[0 + yych] & 128) {
       goto yy827;
     }
-    if (yych <= 0xDF) {
-      if (yych <= '=') {
-        if (yych == '\n')
+    if (yych <= 0xE0) {
+      if (yych <= '>') {
+        if (yych <= 0x00)
           goto yy817;
-        goto yy819;
+        if (yych <= '=')
+          goto yy819;
       } else {
-        if (yych <= '>')
-          goto yy829;
         if (yych <= 0x7F)
           goto yy819;
         if (yych <= 0xC1)
           goto yy817;
-        goto yy818;
+        if (yych <= 0xDF)
+          goto yy818;
+        goto yy822;
       }
     } else {
       if (yych <= 0xEF) {
-        if (yych <= 0xE0)
-          goto yy822;
         if (yych == 0xED)
           goto yy826;
         goto yy816;
@@ -13773,7 +13725,6 @@ bufsize_t _scan_html_block_end_2(const unsigned char *p) {
         goto yy817;
       }
     }
-  yy829:
     yyaccept = 1;
     marker = ++p;
     yych = *p;
@@ -13782,7 +13733,7 @@ bufsize_t _scan_html_block_end_2(const unsigned char *p) {
     }
     if (yych <= 0xEC) {
       if (yych <= 0xC1) {
-        if (yych <= '\n')
+        if (yych <= 0x00)
           goto yy830;
         if (yych <= '-')
           goto yy821;
@@ -13820,7 +13771,7 @@ bufsize_t _scan_html_block_end_3(const unsigned char *p) {
     unsigned char yych;
     unsigned int yyaccept = 0;
     static const unsigned char yybm[] = {
-        64, 64, 64, 64, 64, 64, 64, 64, 64, 64,  0,  64, 64, 64, 64, 64, 64, 64,
+        0,  64, 64, 64, 64, 64, 64, 64, 64, 64,  64, 64, 64, 64, 64, 64, 64, 64,
         64, 64, 64, 64, 64, 64, 64, 64, 64, 64,  64, 64, 64, 64, 64, 64, 64, 64,
         64, 64, 64, 64, 64, 64, 64, 64, 64, 64,  64, 64, 64, 64, 64, 64, 64, 64,
         64, 64, 64, 64, 64, 64, 64, 64, 64, 128, 64, 64, 64, 64, 64, 64, 64, 64,
@@ -13837,23 +13788,24 @@ bufsize_t _scan_html_block_end_3(const unsigned char *p) {
         0,  0,  0,  0,
     };
     yych = *p;
-    if (yych <= 0xDF) {
-      if (yych <= '>') {
-        if (yych == '\n')
-          goto yy835;
-      } else {
-        if (yych <= '?')
-          goto yy836;
-        if (yych <= 0x7F)
+    if (yych <= 0xE0) {
+      if (yych <= '?') {
+        if (yych <= 0x00)
           goto yy833;
-        if (yych <= 0xC1)
+        if (yych <= '>')
           goto yy835;
-        goto yy837;
+        goto yy836;
+      } else {
+        if (yych <= 0x7F)
+          goto yy835;
+        if (yych <= 0xC1)
+          goto yy833;
+        if (yych <= 0xDF)
+          goto yy837;
+        goto yy838;
       }
     } else {
       if (yych <= 0xEF) {
-        if (yych <= 0xE0)
-          goto yy838;
         if (yych == 0xED)
           goto yy840;
         goto yy839;
@@ -13864,30 +13816,28 @@ bufsize_t _scan_html_block_end_3(const unsigned char *p) {
           goto yy842;
         if (yych <= 0xF4)
           goto yy843;
-        goto yy835;
       }
     }
   yy833:
-    yyaccept = 0;
-    yych = *(marker = ++p);
-    if (yych <= 0x7F) {
-      if (yych != '\n')
-        goto yy848;
-    } else {
-      if (yych <= 0xC1)
-        goto yy834;
-      if (yych <= 0xF4)
-        goto yy848;
-    }
+    ++p;
   yy834 : { return 0; }
   yy835:
-    yych = *++p;
+    yyaccept = 0;
+    yych = *(marker = ++p);
+    if (yych <= 0x00)
+      goto yy834;
+    if (yych <= 0x7F)
+      goto yy848;
+    if (yych <= 0xC1)
+      goto yy834;
+    if (yych <= 0xF4)
+      goto yy848;
     goto yy834;
   yy836:
     yyaccept = 0;
     yych = *(marker = ++p);
     if (yych <= '>') {
-      if (yych == '\n')
+      if (yych <= 0x00)
         goto yy834;
       if (yych <= '=')
         goto yy848;
@@ -13986,7 +13936,7 @@ bufsize_t _scan_html_block_end_3(const unsigned char *p) {
     }
     if (yych <= 0xEC) {
       if (yych <= 0xC1) {
-        if (yych <= '\n')
+        if (yych <= 0x00)
           goto yy845;
         if (yych >= '@')
           goto yy845;
@@ -14018,24 +13968,23 @@ bufsize_t _scan_html_block_end_3(const unsigned char *p) {
     if (yybm[0 + yych] & 128) {
       goto yy849;
     }
-    if (yych <= 0xDF) {
-      if (yych <= '=') {
-        if (yych == '\n')
+    if (yych <= 0xE0) {
+      if (yych <= '>') {
+        if (yych <= 0x00)
           goto yy845;
-        goto yy847;
+        if (yych <= '=')
+          goto yy847;
+        goto yy856;
       } else {
-        if (yych <= '>')
-          goto yy856;
         if (yych <= 0x7F)
           goto yy847;
         if (yych <= 0xC1)
           goto yy845;
-        goto yy846;
+        if (yych <= 0xDF)
+          goto yy846;
       }
     } else {
       if (yych <= 0xEF) {
-        if (yych <= 0xE0)
-          goto yy851;
         if (yych == 0xED)
           goto yy855;
         goto yy844;
@@ -14098,7 +14047,7 @@ bufsize_t _scan_html_block_end_3(const unsigned char *p) {
     }
     if (yych <= 0xEC) {
       if (yych <= 0xC1) {
-        if (yych <= '\n')
+        if (yych <= 0x00)
           goto yy857;
         if (yych <= '?')
           goto yy849;
@@ -14136,7 +14085,7 @@ bufsize_t _scan_html_block_end_4(const unsigned char *p) {
     unsigned char yych;
     unsigned int yyaccept = 0;
     static const unsigned char yybm[] = {
-        64, 64, 64, 64, 64, 64, 64, 64, 64,  64, 0,  64, 64, 64, 64, 64, 64, 64,
+        0,  64, 64, 64, 64, 64, 64, 64, 64,  64, 64, 64, 64, 64, 64, 64, 64, 64,
         64, 64, 64, 64, 64, 64, 64, 64, 64,  64, 64, 64, 64, 64, 64, 64, 64, 64,
         64, 64, 64, 64, 64, 64, 64, 64, 64,  64, 64, 64, 64, 64, 64, 64, 64, 64,
         64, 64, 64, 64, 64, 64, 64, 64, 128, 64, 64, 64, 64, 64, 64, 64, 64, 64,
@@ -14153,23 +14102,24 @@ bufsize_t _scan_html_block_end_4(const unsigned char *p) {
         0,  0,  0,  0,
     };
     yych = *p;
-    if (yych <= 0xDF) {
-      if (yych <= '=') {
-        if (yych == '\n')
-          goto yy862;
-      } else {
-        if (yych <= '>')
-          goto yy863;
-        if (yych <= 0x7F)
+    if (yych <= 0xE0) {
+      if (yych <= '>') {
+        if (yych <= 0x00)
           goto yy860;
-        if (yych <= 0xC1)
+        if (yych <= '=')
           goto yy862;
-        goto yy865;
+        goto yy863;
+      } else {
+        if (yych <= 0x7F)
+          goto yy862;
+        if (yych <= 0xC1)
+          goto yy860;
+        if (yych <= 0xDF)
+          goto yy865;
+        goto yy866;
       }
     } else {
       if (yych <= 0xEF) {
-        if (yych <= 0xE0)
-          goto yy866;
         if (yych == 0xED)
           goto yy868;
         goto yy867;
@@ -14180,37 +14130,34 @@ bufsize_t _scan_html_block_end_4(const unsigned char *p) {
           goto yy870;
         if (yych <= 0xF4)
           goto yy871;
-        goto yy862;
       }
     }
   yy860:
-    yyaccept = 0;
-    yych = *(marker = ++p);
-    if (yych <= 0x7F) {
-      if (yych != '\n')
-        goto yy876;
-    } else {
-      if (yych <= 0xC1)
-        goto yy861;
-      if (yych <= 0xF4)
-        goto yy876;
-    }
+    ++p;
   yy861 : { return 0; }
   yy862:
-    yych = *++p;
+    yyaccept = 0;
+    yych = *(marker = ++p);
+    if (yych <= 0x00)
+      goto yy861;
+    if (yych <= 0x7F)
+      goto yy876;
+    if (yych <= 0xC1)
+      goto yy861;
+    if (yych <= 0xF4)
+      goto yy876;
     goto yy861;
   yy863:
     yyaccept = 1;
     yych = *(marker = ++p);
-    if (yych <= 0x7F) {
-      if (yych != '\n')
-        goto yy876;
-    } else {
-      if (yych <= 0xC1)
-        goto yy864;
-      if (yych <= 0xF4)
-        goto yy876;
-    }
+    if (yych <= 0x00)
+      goto yy864;
+    if (yych <= 0x7F)
+      goto yy876;
+    if (yych <= 0xC1)
+      goto yy864;
+    if (yych <= 0xF4)
+      goto yy876;
   yy864 : { return (bufsize_t)(p - start); }
   yy865:
     yyaccept = 0;
@@ -14297,7 +14244,7 @@ bufsize_t _scan_html_block_end_4(const unsigned char *p) {
     }
     if (yych <= 0xEC) {
       if (yych <= 0xC1) {
-        if (yych <= '\n')
+        if (yych <= 0x00)
           goto yy873;
         if (yych >= '?')
           goto yy873;
@@ -14332,7 +14279,7 @@ bufsize_t _scan_html_block_end_4(const unsigned char *p) {
     }
     if (yych <= 0xEC) {
       if (yych <= 0xC1) {
-        if (yych <= '\n')
+        if (yych <= 0x00)
           goto yy864;
         if (yych <= '>')
           goto yy877;
@@ -14410,7 +14357,7 @@ bufsize_t _scan_html_block_end_5(const unsigned char *p) {
     unsigned char yych;
     unsigned int yyaccept = 0;
     static const unsigned char yybm[] = {
-        64, 64, 64, 64,  64, 64, 64, 64, 64, 64, 0,  64, 64, 64, 64, 64, 64, 64,
+        0,  64, 64, 64,  64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
         64, 64, 64, 64,  64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
         64, 64, 64, 64,  64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
         64, 64, 64, 64,  64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
@@ -14427,23 +14374,24 @@ bufsize_t _scan_html_block_end_5(const unsigned char *p) {
         0,  0,  0,  0,
     };
     yych = *p;
-    if (yych <= 0xDF) {
-      if (yych <= '\\') {
-        if (yych == '\n')
-          goto yy888;
-      } else {
-        if (yych <= ']')
-          goto yy889;
-        if (yych <= 0x7F)
+    if (yych <= 0xE0) {
+      if (yych <= ']') {
+        if (yych <= 0x00)
           goto yy886;
-        if (yych <= 0xC1)
+        if (yych <= '\\')
           goto yy888;
-        goto yy890;
+        goto yy889;
+      } else {
+        if (yych <= 0x7F)
+          goto yy888;
+        if (yych <= 0xC1)
+          goto yy886;
+        if (yych <= 0xDF)
+          goto yy890;
+        goto yy891;
       }
     } else {
       if (yych <= 0xEF) {
-        if (yych <= 0xE0)
-          goto yy891;
         if (yych == 0xED)
           goto yy893;
         goto yy892;
@@ -14454,24 +14402,22 @@ bufsize_t _scan_html_block_end_5(const unsigned char *p) {
           goto yy895;
         if (yych <= 0xF4)
           goto yy896;
-        goto yy888;
       }
     }
   yy886:
-    yyaccept = 0;
-    yych = *(marker = ++p);
-    if (yych <= 0x7F) {
-      if (yych != '\n')
-        goto yy901;
-    } else {
-      if (yych <= 0xC1)
-        goto yy887;
-      if (yych <= 0xF4)
-        goto yy901;
-    }
+    ++p;
   yy887 : { return 0; }
   yy888:
-    yych = *++p;
+    yyaccept = 0;
+    yych = *(marker = ++p);
+    if (yych <= 0x00)
+      goto yy887;
+    if (yych <= 0x7F)
+      goto yy901;
+    if (yych <= 0xC1)
+      goto yy887;
+    if (yych <= 0xF4)
+      goto yy901;
     goto yy887;
   yy889:
     yyaccept = 0;
@@ -14479,17 +14425,15 @@ bufsize_t _scan_html_block_end_5(const unsigned char *p) {
     if (yybm[0 + yych] & 128) {
       goto yy908;
     }
-    if (yych <= 0x7F) {
-      if (yych == '\n')
-        goto yy887;
-      goto yy901;
-    } else {
-      if (yych <= 0xC1)
-        goto yy887;
-      if (yych <= 0xF4)
-        goto yy901;
+    if (yych <= 0x00)
       goto yy887;
-    }
+    if (yych <= 0x7F)
+      goto yy901;
+    if (yych <= 0xC1)
+      goto yy887;
+    if (yych <= 0xF4)
+      goto yy901;
+    goto yy887;
   yy890:
     yyaccept = 0;
     yych = *(marker = ++p);
@@ -14575,7 +14519,7 @@ bufsize_t _scan_html_block_end_5(const unsigned char *p) {
     }
     if (yych <= 0xEC) {
       if (yych <= 0xC1) {
-        if (yych <= '\n')
+        if (yych <= 0x00)
           goto yy898;
         if (yych >= '^')
           goto yy898;
@@ -14609,7 +14553,7 @@ bufsize_t _scan_html_block_end_5(const unsigned char *p) {
     }
     if (yych <= 0xEC) {
       if (yych <= 0xC1) {
-        if (yych <= '\n')
+        if (yych <= 0x00)
           goto yy898;
         if (yych <= ']')
           goto yy908;
@@ -14681,24 +14625,23 @@ bufsize_t _scan_html_block_end_5(const unsigned char *p) {
     if (yybm[0 + yych] & 128) {
       goto yy908;
     }
-    if (yych <= 0xDF) {
-      if (yych <= '=') {
-        if (yych == '\n')
+    if (yych <= 0xE0) {
+      if (yych <= '>') {
+        if (yych <= 0x00)
           goto yy898;
-        goto yy900;
+        if (yych <= '=')
+          goto yy900;
       } else {
-        if (yych <= '>')
-          goto yy910;
         if (yych <= 0x7F)
           goto yy900;
         if (yych <= 0xC1)
           goto yy898;
-        goto yy899;
+        if (yych <= 0xDF)
+          goto yy899;
+        goto yy903;
       }
     } else {
       if (yych <= 0xEF) {
-        if (yych <= 0xE0)
-          goto yy903;
         if (yych == 0xED)
           goto yy907;
         goto yy897;
@@ -14712,7 +14655,6 @@ bufsize_t _scan_html_block_end_5(const unsigned char *p) {
         goto yy898;
       }
     }
-  yy910:
     yyaccept = 1;
     marker = ++p;
     yych = *p;
@@ -14721,7 +14663,7 @@ bufsize_t _scan_html_block_end_5(const unsigned char *p) {
     }
     if (yych <= 0xEC) {
       if (yych <= 0xC1) {
-        if (yych <= '\n')
+        if (yych <= 0x00)
           goto yy911;
         if (yych <= ']')
           goto yy902;

--- a/src/scanners.re
+++ b/src/scanners.re
@@ -156,7 +156,7 @@ bufsize_t _scan_html_block_end_1(const unsigned char *p)
   const unsigned char *marker = NULL;
   const unsigned char *start = p;
 /*!re2c
-  .* [<] [/] ('script'|'pre'|'style') [>] { return (bufsize_t)(p - start); }
+  [^\x00]* [<] [/] ('script'|'pre'|'style') [>] { return (bufsize_t)(p - start); }
   * { return 0; }
 */
 }
@@ -167,7 +167,7 @@ bufsize_t _scan_html_block_end_2(const unsigned char *p)
   const unsigned char *marker = NULL;
   const unsigned char *start = p;
 /*!re2c
-  .* '-->' { return (bufsize_t)(p - start); }
+  [^\x00]* '-->' { return (bufsize_t)(p - start); }
   * { return 0; }
 */
 }
@@ -178,7 +178,7 @@ bufsize_t _scan_html_block_end_3(const unsigned char *p)
   const unsigned char *marker = NULL;
   const unsigned char *start = p;
 /*!re2c
-  .* '?>' { return (bufsize_t)(p - start); }
+  [^\x00]* '?>' { return (bufsize_t)(p - start); }
   * { return 0; }
 */
 }
@@ -189,7 +189,7 @@ bufsize_t _scan_html_block_end_4(const unsigned char *p)
   const unsigned char *marker = NULL;
   const unsigned char *start = p;
 /*!re2c
-  .* '>' { return (bufsize_t)(p - start); }
+  [^\x00]* '>' { return (bufsize_t)(p - start); }
   * { return 0; }
 */
 }
@@ -200,7 +200,7 @@ bufsize_t _scan_html_block_end_5(const unsigned char *p)
   const unsigned char *marker = NULL;
   const unsigned char *start = p;
 /*!re2c
-  .* ']]>' { return (bufsize_t)(p - start); }
+  [^\x00]* ']]>' { return (bufsize_t)(p - start); }
   * { return 0; }
 */
 }

--- a/src/scanners.re
+++ b/src/scanners.re
@@ -156,7 +156,7 @@ bufsize_t _scan_html_block_end_1(const unsigned char *p)
   const unsigned char *marker = NULL;
   const unsigned char *start = p;
 /*!re2c
-  [^\x00]* [<] [/] ('script'|'pre'|'style') [>] { return (bufsize_t)(p - start); }
+  [^\n\x00]* [<] [/] ('script'|'pre'|'style') [>] { return (bufsize_t)(p - start); }
   * { return 0; }
 */
 }
@@ -167,7 +167,7 @@ bufsize_t _scan_html_block_end_2(const unsigned char *p)
   const unsigned char *marker = NULL;
   const unsigned char *start = p;
 /*!re2c
-  [^\x00]* '-->' { return (bufsize_t)(p - start); }
+  [^\n\x00]* '-->' { return (bufsize_t)(p - start); }
   * { return 0; }
 */
 }
@@ -178,7 +178,7 @@ bufsize_t _scan_html_block_end_3(const unsigned char *p)
   const unsigned char *marker = NULL;
   const unsigned char *start = p;
 /*!re2c
-  [^\x00]* '?>' { return (bufsize_t)(p - start); }
+  [^\n\x00]* '?>' { return (bufsize_t)(p - start); }
   * { return 0; }
 */
 }
@@ -189,7 +189,7 @@ bufsize_t _scan_html_block_end_4(const unsigned char *p)
   const unsigned char *marker = NULL;
   const unsigned char *start = p;
 /*!re2c
-  [^\x00]* '>' { return (bufsize_t)(p - start); }
+  [^\n\x00]* '>' { return (bufsize_t)(p - start); }
   * { return 0; }
 */
 }
@@ -200,7 +200,7 @@ bufsize_t _scan_html_block_end_5(const unsigned char *p)
   const unsigned char *marker = NULL;
   const unsigned char *start = p;
 /*!re2c
-  [^\x00]* ']]>' { return (bufsize_t)(p - start); }
+  [^\n\x00]* ']]>' { return (bufsize_t)(p - start); }
   * { return 0; }
 */
 }


### PR DESCRIPTION
The existing negated character classes (`[^…]`) are careful to always include `\x00` in the characters excluded, but these `.` catch-alls can scan right past the terminating NUL placed at the end of the buffer by `_scan_at`.

As such, buffer overruns can occur.