### PR TITLE
Use unsigned integer when shifting

### DIFF
--- a/src/commonmark.c
+++ b/src/commonmark.c
@@ -93,7 +93,7 @@ static int shortest_unused_backtick_sequence(const char *code) {
       current++;
     } else {
       if (current > 0 && current < 32) {
-        used |= (1 << current);
+        used |= (1U << current);
       }
       current = 0;
     }


### PR DESCRIPTION
(original at github#39)

A UBSAN warning can be triggered when handling a long sequence of backticks:

src/commonmark.c:98:20: runtime error: left shift of 1 by 31 places cannot be represented in type 'int'

which can be triggered by:

```
| a | b |
| --- | --** `c```````````````````````````````- |
| c | `|d` \| e |
```